### PR TITLE
fix: Don't strip spaces from "ignore folders" paths

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -757,7 +757,7 @@ export default class TagFolderPlugin extends Plugin {
 
 		const ignoreFolders = this.settings.ignoreFolders
 			.toLocaleLowerCase()
-			.replace(/\n| /g, "")
+			.replace(/\n/g, "")
 			.split(",")
 			.map((e) => e.trim())
 			.filter((e) => !!e);


### PR DESCRIPTION
Hi, great job on the plugin. I noticed a small bug where the "Ignore Folders" list doesn't support paths that contain spaces. I don't see a reason why the should get stripped so I switched this to just strip the newlines.

Example:

<img width="750" alt="image" src="https://user-images.githubusercontent.com/693981/156851344-9cef1a92-b674-4975-b722-b431986d81d9.png">
