### PR TITLE
fix: Match the dom structure of the file explorer, add missing class

### DIFF
--- a/TreeItemComponent.svelte
+++ b/TreeItemComponent.svelte
@@ -68,13 +68,10 @@
 
 <slot>
 	{#if "tag" in entry && (currentDepth <= _maxDepth || entry.tag.startsWith(SUBTREE_MARK))}
-		<div class="nav-folder  {collapsed ? 'is-collapsed' : ''}">
+		<div class="nav-folder" class:is-collapsed={collapsed}>
 			<div
-				class="nav-folder-title {entry.children &&
-				collapsed &&
-				isSelected
-					? 'is-active'
-					: ''}"
+				class="nav-folder-title"
+				class:is-active={entry.children && collapsed && isSelected}
 				on:click={() => toggleFolder(entry)}
 				on:contextmenu={(e) => handleContextMenu(e, currentPath, entry)}
 			>
@@ -140,13 +137,16 @@
 			{/if}
 		</div>
 	{:else if "path" in entry}
-		<div
-			class="nav-file-title {isSelected ? 'is-active' : ''}"
-			on:click={() => openfileLocal(entry)}
-			on:contextmenu={(e) => handleContextMenu(e, currentPath, entry)}
-		>
-			<div class="nav-file-title-content">
-				{entry.displayName}
+		<div class="nav-file">
+			<div
+				class="nav-file-title"
+				class:is-active={isSelected}
+				on:click={() => openfileLocal(entry)}
+				on:contextmenu={(e) => handleContextMenu(e, currentPath, entry)}
+			>
+				<div class="nav-file-title-content">
+					{entry.displayName}
+				</div>
 			</div>
 		</div>
 	{/if}


### PR DESCRIPTION
Hi, in the file explorer, there's an extra div with the class "nav-file" that is missing from the TagFolder view. Adding it fixes some of the alignment with custom themes.