### PR TITLE
Adds setting for storing tags of new notes in frontmatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,10 @@ When we enable this feature, our notes will be tagged as their freshness automat
 | 📚    | Within 7 days         |
 | 🗄    | Older than 7 days ago |
 
+##### Store tags in frontmatter for new notes
+
+This setting changes how tags are stored in new notes created by TagFolder. When disabled, tags are stored as #hashtags at the top of new notes. When enabled, tags are stored in the frontmatter and displayed in the note's Properties.
+
 #### Actions
 
 ##### Search tags inside TagFolder when clicking tags

--- a/TagFolderList.ts
+++ b/TagFolderList.ts
@@ -55,18 +55,7 @@ export class TagFolderList extends TagFolderViewBase {
 	}
 
 	async newNote(evt: MouseEvent) {
-
-		const expandedTags = this.state.tags.map(e => trimTrailingSlash(e))
-			.map(e => e.split("/")
-				.filter(ee => !isSpecialTag(ee))
-				.join("/")).filter(e => e != "")
-			.map((e) => "#" + e)
-			.join(" ")
-			.trim();
-
-		//@ts-ignore
-		const ww = await this.app.fileManager.createAndOpenMarkdownFile() as TFile;
-		await this.app.vault.append(ww, expandedTags);
+		await this.plugin.createNewNote(this.state.tags);
 	}
 
 	getViewType() {

--- a/TagFolderViewBase.ts
+++ b/TagFolderViewBase.ts
@@ -179,9 +179,7 @@ export abstract class TagFolderViewBase extends ItemView {
                     .setTitle(`New note ${targetTag ? "in here" : "as like this"}`)
                     .setIcon("create-new")
                     .onClick(async () => {
-                        //@ts-ignore
-                        const ww = await this.app.fileManager.createAndOpenMarkdownFile() as TFile;
-                        await this.app.vault.append(ww, expandedTags);
+                        await this.plugin.createNewNote(trail);
                     })
             );
             if (targetTag) {

--- a/main.ts
+++ b/main.ts
@@ -46,6 +46,13 @@ import {
 	secondsToFreshness,
 	unique,
 	updateItemsLinkMap,
+	ancestorToLongestTag,
+	ancestorToTags,
+	joinPartialPath,
+	removeIntermediatePath,
+	trimTrailingSlash,
+	isSpecialTag,
+	trimPrefix
 } from "./util";
 import { ScrollView } from "./ScrollView";
 import { TagFolderView } from "./TagFolderView";
@@ -267,9 +274,8 @@ export default class TagFolderPlugin extends Plugin {
 				const cache = this.app.metadataCache.getFileCache(file);
 				if (!cache) return;
 				const tags = getAllTags(cache) ?? [];
-				//@ts-ignore
-				const ww = await this.app.fileManager.createAndOpenMarkdownFile() as TFile;
-				await this.app.vault.append(ww, tags.join(" "));
+				const tagsWithoutPrefix = tags.map((e) => trimPrefix(e, "#"));
+				await this.createNewNote(tagsWithoutPrefix);
 			},
 		});
 		this.metadataCacheChanged = this.metadataCacheChanged.bind(this);
@@ -1106,6 +1112,36 @@ export default class TagFolderPlugin extends Plugin {
 			theLeaf
 		);
 	}
+
+	async createNewNote(tags?: string[]) {
+		const expandedTagsAll = ancestorToLongestTag(ancestorToTags(joinPartialPath(removeIntermediatePath(tags ?? []))))
+			.map((e) => trimTrailingSlash(e));
+
+		const expandedTags = expandedTagsAll
+			.map((e) => e
+				.split("/")
+				.filter((ee) => !isSpecialTag(ee))
+				.join("/"))
+			.filter((e) => e != "")
+			.map((e) => "#" + e)
+			.join(" ")
+			.trim();
+
+		//@ts-ignore
+		const ww = await this.app.fileManager.createAndOpenMarkdownFile() as TFile;
+		if (this.settings.useFrontmatterTagsForNewNotes) {
+			await this.app.fileManager.processFrontMatter(ww, (matter) => {
+				matter.tags = matter.tags ?? [];
+				matter.tags = expandedTagsAll
+					.filter(e => !isSpecialTag(e))
+					.filter(e => matter.tags.indexOf(e) < 0)
+					.concat(matter.tags);
+			});
+		}
+		else {
+			await this.app.vault.append(ww, expandedTags);
+		}
+	}
 }
 
 class TagFolderSettingTab extends PluginSettingTab {
@@ -1293,6 +1329,18 @@ class TagFolderSettingTab extends PluginSettingTab {
 					.setValue(this.plugin.settings.useVirtualTag)
 					.onChange(async (value) => {
 						this.plugin.settings.useVirtualTag = value;
+						await this.plugin.saveSettings();
+					});
+			});
+
+		new Setting(containerEl)
+			.setName("Store tags in frontmatter for new notes")
+			.setDesc("Otherwise, tags are stored with #hashtags at the top of the note")
+			.addToggle((toggle) => {
+				toggle
+					.setValue(this.plugin.settings.useFrontmatterTagsForNewNotes)
+					.onChange(async (value) => {
+						this.plugin.settings.useFrontmatterTagsForNewNotes = value;
 						await this.plugin.saveSettings();
 					});
 			});

--- a/types.ts
+++ b/types.ts
@@ -69,6 +69,7 @@ export interface TagFolderSettings {
 	tagInfo: string;
 	mergeRedundantCombination: boolean;
 	useVirtualTag: boolean;
+	useFrontmatterTagsForNewNotes: boolean,
 	doNotSimplifyTags: boolean;
 	overrideTagClicking: boolean;
 	useMultiPaneList: boolean;
@@ -104,6 +105,7 @@ export const DEFAULT_SETTINGS: TagFolderSettings = {
 	tagInfo: "pininfo.md",
 	mergeRedundantCombination: false,
 	useVirtualTag: false,
+	useFrontmatterTagsForNewNotes: false,
 	doNotSimplifyTags: false,
 	overrideTagClicking: false,
 	useMultiPaneList: false,


### PR DESCRIPTION
Hello,

I like to store my tags in the frontmatter instead of in the file as hashtags. This pull request adds a setting for doing just that.

Instead of looking like this:

```
#mytag
```

Notes will look like this with the setting is enabled:

```
---
tags:
  - mytag
---
```

### Tag expansion and clean-up logic
I'm a bit unsure about the tag expansion and clean-up logic.

There seems to be some corner-cases where the logic is incorrect. From what I can tell, this is not a regression, merely the same behavior as before.

For example, creating a new note for the tag structure `#project -> EA-P230415` results in two tags being added to the new note instead of one.

![image](https://github.com/vrtmrz/obsidian-tagfolder/assets/1451274/8837d7ea-ab7a-47fb-90b1-e57ef5fcd75d)

What is created:

![image](https://github.com/vrtmrz/obsidian-tagfolder/assets/1451274/6c036c44-a645-4a1c-89bb-f6bffda04fde)

What is expected:

![image](https://github.com/vrtmrz/obsidian-tagfolder/assets/1451274/a1f4f69d-7b2a-4843-8e5f-21bb2fff3d28)

This problem only occur when there is a single note with the "#project/EA-P230415" tag. The problem goes away when there is more than one note:

![image](https://github.com/vrtmrz/obsidian-tagfolder/assets/1451274/ae5fd6f8-fcb3-4e17-a813-3ccd70aabcc0)

Something to look out for and perhaps fix in a future release.

### Thank you

Thanks for the awesome work. I hope you find this change useful.


