### PR TITLE
Reveal TagFolder view after clicking a tag

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -349,10 +349,6 @@ export default class TagFolderPlugin extends Plugin {
 				} else {
 					this.setSearchString(tagString);
 				}
-				const leaf = this.getView()?.leaf;
-				if (leaf) {
-					this.app.workspace.revealLeaf(leaf);
-				}
 				event.preventDefault();
 				event.stopPropagation();
 
@@ -367,6 +363,10 @@ export default class TagFolderPlugin extends Plugin {
 				const tagString = targetEl.innerText.substring(1);
 				if (tagString) {
 					setTagSearchString(event, tagString);
+					const leaf = this.getView()?.leaf;
+					if (leaf) {
+						this.app.workspace.revealLeaf(leaf);
+					}
 				}
 			}, { capture: true })
 		);
@@ -400,6 +400,10 @@ export default class TagFolderPlugin extends Plugin {
 				} while (enumTags);
 				tagString = tagString.substring(1) //Snip hash.
 				setTagSearchString(event, tagString);
+				const leaf = this.getView()?.leaf;
+				if (leaf) {
+					this.app.workspace.revealLeaf(leaf);
+				}
 			}, { capture: true })
 		);
 		selectedTags.subscribe(newTags => {

--- a/main.ts
+++ b/main.ts
@@ -348,7 +348,10 @@ export default class TagFolderPlugin extends Plugin {
 					}
 				} else {
 					this.setSearchString(tagString);
-
+				}
+				const leaf = this.getView()?.leaf;
+				if (leaf) {
+					this.app.workspace.revealLeaf(leaf);
 				}
 				event.preventDefault();
 				event.stopPropagation();


### PR DESCRIPTION
Thank you so much for this awesome plugin, and a happy new year!

I've noticed that when I turn on the `Search tags inside TagFolder when clicking tags` option and click a tag in a markdown view, it doesn't automatically open the left sidebar (and hence the TagFolder view).

If the left sidebar is hidden at first, it even looks like nothing happened, which can be confusing for some users.

The option is meant to override the default behavior where clicking a tag opens the core search view in the sidebar. So I think it would be more user-friendly if this option behaved the same.

If this is intentional, please let me know. I can add a setting to choose whether the left sidebar should be opened or not. Thank you!
