### PR TITLE
feature: insert via template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,294 +1,40 @@
-## TagFolder
+## MyTagFolder
 
-This is the plugin that shows your tags like folders.
+This is my custom build of the Obsidian TagFolder plugin.
 
-![screenshot](images/screenshot.png)
+Original project: https://github.com/vrtmrz/obsidian-tagfolder
 
-### How to use
+My fork keeps the original plugin behavior and adds my changes on top of it.
 
-Install this plugin, press `Ctrl+p`, and choose "Show Tag Folder".
+### What I changed
 
-### Behavior
+- Added support for creating new notes from a configured template when using TagFolder.
+- Added a TagFolder context-menu action for renaming tags through TagWrangler.
 
-This plugin creates a tree by tags permutation.
+### Install my build
 
-Like this,
-### Simple case
+Download the ready-to-install zip from the GitHub Release:
 
-If you have docs,
-```
-Apple : #food #red #sweet
-Pear  : #food #green #sweet
-Tuna  : #food #red
-```
-![](./images/simplecase.png)
+https://github.com/boabab/obsidian-tagfolder/releases/download/mytagfolder-v0.18.13-20260430/mytagfolder-plugin.zip
 
-...and more are shown.
+Unzip it into this folder in your Obsidian vault:
 
-### Case of respecting nested tags
-
-The nested tag works well for Tag Folder.
-
-Tag Folder respects nested tags and makes the dedicated hierarchy. The nested child doesn't leak out over the parent.
-
-```
-TagFolder Readme: #dev #readme #2021/12/10 #status/draft
-Technical information: #dev #note #2021/12/09 #status/draft
-SelfHosted LiveSync Readme : #dev #readme #2021/12/06 #status/proofread
-Old Note: #dev #readme #2021/12/10 #status/abandoned
-```
-#### Tag hierarchy of status
-
-![](./images/respect-nestedtag-1.png)
-
-#### Tag hierarchy of date
-
-![](./images/respect-nestedtag-2.png)
-
-
-#### Search tags
-You can search tags. like this:
-
-```
-sweet -red | food -sweet
-```
-When using this filter, this plugin shows only "Pear" (Sweet but not red) and "Tuna" (food but not sweet).
-
-### Settings
-
-#### Behavior
-
-##### Always Open
-
-Place TagFolder on the left pane and activate it at every Obsidian launch.
-
-##### Use pinning
-We can pin the tag if we enable this option.  
-When this feature is enabled, the pin information is saved in the file set in the next configuration.  
-Pinned tags are sorted according to `key` in the frontmatter of `taginfo.md`.
-
-##### Pin information file
-We can change the name of the file in which pin information is saved.
-This can be configured also from the context-menu.
-
-| Item     | Meaning of the value                                                                              |
-| -------- | ------------------------------------------------------------------------------------------------- |
-| key      | If exists, the tag is pinned.                                                                     |
-| mark     | The label which is shown instead of `📌`.                                                          |
-| alt      | The tag will be shown as this. But they will not be merged into the same one. No `#` is required. |
-| redirect | The tag will be redirected to the configured one and will be merged. No `#` is required.          |
-
-##### Disable narrowing down
-TagFolder creates the folder structure by collecting combinations of tags that are used in the same note, to make it easier for us to find notes.
-When this feature is enabled, collected combinations are no longer structured and show as we have organized them in a manner.
-
-
-#### Files
-
-##### Display Method
-
-You can configure how the entry shows.
-
-##### Order method
-
-You can order items by:
-- Displaying name
-- Filename
-- Modified time
-- Fullpath of the file
-
-##### Use title
-
-When you enable this option, the value in the frontmatter or first level one heading will be shown instead of `NAME`.
-
-##### Frontmatter path
-Dotted path to retrieve title from frontmatter.
-
-#### Tags
-
-##### Order method
-
-You can order tags by:
-- Filename
-- Count of items
-
-##### Use virtual tags
-
-When we enable this feature, our notes will be tagged as their freshness automatically.
-| Icon | Edited ...            |
-| ---- | --------------------- |
-| 🕐    | Within an hour        |
-| 📖    | Within 6 hours        |
-| 📗    | Within 3 days         |
-| 📚    | Within 7 days         |
-| 🗄    | Older than 7 days ago |
-
-##### Display folder as tag
-
-When we enable this feature, the folder will be shown as a tag.
-
-##### Store tags in frontmatter for new notes
-
-This setting changes how tags are stored in new notes created by TagFolder. When disabled, tags are stored as #hashtags at the top of new notes. When enabled, tags are stored in the frontmatter and displayed in the note's Properties.
-
-##### Template for new notes
-
-When this setting is set to a valid markdown template path, TagFolder uses that template immediately when creating a new note from the tag tree. The `.md` extension is optional. If the setting is empty or invalid, TagFolder opens a template picker.
-
-Templates can include these placeholders, which are replaced with the tags from the clicked location:
-
-| Placeholder        | Replacement                         |
-| ------------------ | ----------------------------------- |
-| `{{expandedTags}}` or `{{tags}}` | Tags as hashtags, e.g. `#tag1 #tag2` |
-| `{{tagList}}`      | Tags as comma-separated text, e.g. `tag1, tag2` |
-| `{{tagPath}}`      | Tags as a slash-separated path, e.g. `tag1/tag2` |
-| `{{tagName}}`      | The last tag in the clicked context |
-| `{{tagsJson}}`     | Tags as a JSON array                |
-| `{{tagsYaml}}`     | Tags as YAML list lines             |
-
-#### Actions
-
-##### Search tags inside TagFolder when clicking tags
-We can search tags inside TagFolder when clicking tags instead of opening the default search pane.
-With control and shift keys, we can remove the tag from the search condition or add an exclusion of it to that.
-
-##### List files in a separated pane
-When enabled, files will be shown in a separated pane.
-
-#### Arrangements
-
-##### Hide Items
-
-Configure hiding items.
-- Hide nothing
-- Only intermediates of nested tags
-- All intermediates
-
-If you have these items:
-```
-2021-11-01 : #daily/2021/11 #status/summarized
-2021-11-02 : #daily/2021/11 #status/summarized
-2021-11-03 : #daily/2021/11 #status/jot
-2021-12-01 : #daily/2021/12 #status/jot
+```text
+<your-vault>/.obsidian/plugins/obsidian-tagfolder/
 ```
 
-This setting affects as like below.
-- Hide nothing
+The folder should contain:
 
-```
-daily
-    → 2021
-        → 11
-            status
-                → jot
-                    2021-11-03
-                → summarized
-                    2021-11-01
-                    2021-11-02
-                2021-11-01
-                2021-11-02
-                2021-11-03
-            2021-11-01
-            2021-11-02
-            2021-11-03
-        2021-11-01
-        2021-11-02
-        2021-11-03
-        2021-12-01
-        → 12
-            :
-    2021-11-01
-    2021-11-02
-    2021-11-03
-    2021-12-01
+```text
+main.js
+manifest.json
+styles.css
 ```
 
-- Only intermediates of nested tags
-Hide only intermediates of nested tags, so show items only on the last or break of the nested tags.
-```
-daily
-    → 2021
-        → 11
-            status
-                → jot
-                    2021-11-03
-                → summarized
-                    2021-11-01
-                    2021-11-02
-            2021-11-01
-            2021-11-02
-            2021-11-03
-        → 12
-            :
-```
-- All intermediates
-Hide all intermediates, so show items only deepest.
-```
-daily
-    → 2021
-        → 11
-            status
-                → jot
-                    2021-11-03
-                → summarized
-                    2021-11-01
-                    2021-11-02
-        → 12
-            :
-```
+Restart Obsidian, then open Settings -> Community plugins and enable `MyTagFolder`.
 
-##### Merge redundant combinations
-When this feature is enabled, a/b and b/a are merged into a/b if there are no intermediates.
+### Source branch
 
-##### Do not simplify empty folders
-Keep empty folders, even if they can be simplified.
+The branch with both custom features is:
 
-##### Do not treat nested tags as dedicated levels
-
-If you enable this option, every nested tag is split into normal tags.
-
-`#dev/TagFolder` will be treated like `#dev` and `#TagFolder`.
-
-##### Reduce duplicated parents in nested tags
-
-If we have the doc (e.g., `example note`) with nested tags which have the same parents, like `#topic/calculus`, `#topic/electromagnetics`:
-
-- Disabled
-```
-topic
-     - > calculus
-         topic
-               - > electromagnetics
-                   example note
-         example note 
-```
-- Enabled
-```
-topic
-     - > calculus
-          - > electromagnetics
-              example note
-         example note 
-```
-
-#### Filters
-
-
-##### Target Folders
-If we set this, the plugin will only target files in it.
-
-
-##### Ignore Folders
-
-Ignore documents in specific folders.
-
-
-##### Ignore note Tag
-
-If the note has the tag that is set in here, the note would be treated as there was not.
-
-##### Ignore Tag
-
-Tags that were set here would be treated as there were not.
-
-##### Archive tags
+https://github.com/boabab/obsidian-tagfolder/tree/feature/all-my-features

--- a/README.md
+++ b/README.md
@@ -131,6 +131,21 @@ When we enable this feature, the folder will be shown as a tag.
 
 This setting changes how tags are stored in new notes created by TagFolder. When disabled, tags are stored as #hashtags at the top of new notes. When enabled, tags are stored in the frontmatter and displayed in the note's Properties.
 
+##### Template for new notes
+
+When this setting is set to a valid markdown template path, TagFolder uses that template immediately when creating a new note from the tag tree. The `.md` extension is optional. If the setting is empty or invalid, TagFolder opens a template picker.
+
+Templates can include these placeholders, which are replaced with the tags from the clicked location:
+
+| Placeholder        | Replacement                         |
+| ------------------ | ----------------------------------- |
+| `{{expandedTags}}` or `{{tags}}` | Tags as hashtags, e.g. `#tag1 #tag2` |
+| `{{tagList}}`      | Tags as comma-separated text, e.g. `tag1, tag2` |
+| `{{tagPath}}`      | Tags as a slash-separated path, e.g. `tag1/tag2` |
+| `{{tagName}}`      | The last tag in the clicked context |
+| `{{tagsJson}}`     | Tags as a JSON array                |
+| `{{tagsYaml}}`     | Tags as YAML list lines             |
+
 #### Actions
 
 ##### Search tags inside TagFolder when clicking tags

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ My fork keeps the original plugin behavior and adds my changes on top of it.
 ### What I changed
 
 - Added support for creating new notes from a configured template when using TagFolder.
+- When no template is selected, new notes are created with TagFolder's default behavior. If `Store tags in frontmatter for new notes` is enabled, those fallback notes store their tags in Properties/frontmatter; otherwise the tags are inserted as hashtags.
 - Added a TagFolder context-menu action for renaming tags through TagWrangler.
 
 ### Install my build

--- a/TagFolderViewBase.ts
+++ b/TagFolderViewBase.ts
@@ -1,4 +1,4 @@
-import { ItemView, Menu, Notice } from "obsidian";
+import { ItemView, Menu, Notice, type App } from "obsidian";
 import { mount } from 'svelte'
 import TagFolderPlugin from "./main";
 import {
@@ -27,6 +27,34 @@ function toggleObjectProp(obj: { [key: string]: any }, propName: string, value: 
 		return { ...(obj ?? {}), [propName]: value };
 	}
 }
+
+type TagWranglerPlugin = {
+	rename: (tagName: string, toName?: string) => void | Promise<void>;
+};
+
+type AppWithCommunityPlugins = App & {
+	plugins?: {
+		plugins?: Record<string, unknown>;
+	};
+};
+
+function getTagWranglerPlugin(app: App): TagWranglerPlugin | undefined {
+	const plugin = (app as AppWithCommunityPlugins).plugins?.plugins?.["tag-wrangler"];
+	if (!plugin || typeof (plugin as TagWranglerPlugin).rename != "function") {
+		return undefined;
+	}
+	return plugin as TagWranglerPlugin;
+}
+
+function getRenameTargetTag(expandedTagsAll: string[]) {
+	const tagPath = trimTrailingSlash(expandedTagsAll[expandedTagsAll.length - 1] ?? "");
+	const tagParts = tagPath.split("/").filter((part) => part.trim() != "");
+	if (tagParts.length == 0 || tagParts.some((part) => isSpecialTag(part))) {
+		return undefined;
+	}
+	return tagParts.join("/");
+}
+
 export abstract class TagFolderViewBase extends ItemView {
 	component!: ReturnType<typeof mount>;
 	plugin!: TagFolderPlugin;
@@ -182,6 +210,18 @@ export abstract class TagFolderViewBase extends ItemView {
 						await this.plugin.createNewNote(trail);
 					})
 			);
+			const renameTargetTag = targetTag ? getRenameTargetTag(expandedTagsAll) : undefined;
+			const tagWrangler = renameTargetTag ? getTagWranglerPlugin(this.app) : undefined;
+			if (renameTargetTag && tagWrangler) {
+				menu.addItem((item) =>
+					item
+						.setTitle(`Rename #${renameTargetTag}`)
+						.setIcon("pencil")
+						.onClick(async () => {
+							await tagWrangler.rename(renameTargetTag);
+						})
+				);
+			}
 			if (targetTag) {
 				if (this.plugin.settings.useTagInfo && this.plugin.tagInfo != null) {
 					const tag = targetTag;

--- a/main.ts
+++ b/main.ts
@@ -1,6 +1,7 @@
 /// <reference types="svelte" />
 
 import {
+	AbstractInputSuggest,
 	App,
 	debounce,
 	Editor,
@@ -13,6 +14,7 @@ import {
 	Plugin,
 	PluginSettingTab,
 	Setting,
+	SuggestModal,
 	TFile,
 	WorkspaceLeaf,
 	TAbstractFile,
@@ -103,6 +105,164 @@ function getCompareMethodItems(settings: TagFolderSettings) {
 			return (a: ViewItem, b: ViewItem) =>
 				compare(a.displayName, b.displayName) * invert;
 	}
+}
+
+type NewNoteTemplateChoice = TFile;
+
+function getCoreTemplatesFolder(app: App): string | null {
+	const internalPlugins = (app as App & {
+		internalPlugins?: {
+			getPluginById?: (id: string) => {
+				instance?: {
+					options?: {
+						folder?: string;
+						templateFolder?: string;
+					};
+				};
+			};
+		};
+	}).internalPlugins;
+	const templatesPlugin = internalPlugins?.getPluginById?.("templates");
+	const folder = templatesPlugin?.instance?.options?.folder ?? templatesPlugin?.instance?.options?.templateFolder;
+	if (!folder) return null;
+	const normalizedFolder = normalizePath(folder);
+	return normalizedFolder == "/" ? "" : normalizedFolder;
+}
+
+function getTemplateFiles(app: App) {
+	const templateFolder = getCoreTemplatesFolder(app);
+	const markdownFiles = app.vault.getMarkdownFiles();
+	const templates = templateFolder == null || templateFolder == ""
+		? markdownFiles
+		: markdownFiles.filter((file) => {
+			const path = normalizePath(file.path);
+			return path == templateFolder || path.startsWith(`${templateFolder}/`);
+		});
+
+	return templates.sort((a, b) => compare(a.path, b.path));
+}
+
+class NewNoteTemplateSuggestModal extends SuggestModal<NewNoteTemplateChoice> {
+	private callback?: (template: NewNoteTemplateChoice | false) => void;
+	private templates: TFile[];
+
+	constructor(app: App, templates: TFile[], callback: (template: NewNoteTemplateChoice | false) => void) {
+		super(app);
+		this.templates = templates;
+		this.callback = callback;
+		this.setPlaceholder("Type to search templates...");
+	}
+
+	getSuggestions(query: string): NewNoteTemplateChoice[] {
+		const normalizedQuery = query.toLowerCase();
+		return this.templates.filter((file) =>
+			file.path.toLowerCase().contains(normalizedQuery)
+		);
+	}
+
+	renderSuggestion(template: NewNoteTemplateChoice, el: HTMLElement) {
+		el.createDiv({ text: template.basename });
+		el.createDiv({ text: template.path, cls: "suggestion-note" });
+	}
+
+	onChooseSuggestion(template: NewNoteTemplateChoice) {
+		this.callback?.(template);
+		this.callback = undefined;
+	}
+
+	onClose(): void {
+		setTimeout(() => {
+			if (this.callback) {
+				this.callback(false);
+				this.callback = undefined;
+			}
+		}, 100);
+	}
+}
+
+class NewNoteTemplateInputSuggest extends AbstractInputSuggest<TFile> {
+	private callback: (template: TFile) => void;
+
+	constructor(app: App, inputEl: HTMLInputElement, callback: (template: TFile) => void) {
+		super(app, inputEl);
+		this.callback = callback;
+	}
+
+	getSuggestions(query: string): TFile[] {
+		const normalizedQuery = query.toLowerCase();
+		return getTemplateFiles(this.app).filter((file) =>
+			file.path.toLowerCase().contains(normalizedQuery)
+			|| file.basename.toLowerCase().contains(normalizedQuery)
+		);
+	}
+
+	renderSuggestion(template: TFile, el: HTMLElement) {
+		el.createDiv({ text: template.basename });
+		el.createDiv({ text: template.path, cls: "suggestion-note" });
+	}
+
+	selectSuggestion(template: TFile) {
+		this.setValue(template.path);
+		this.callback(template);
+		this.close();
+	}
+}
+
+function askNewNoteTemplate(app: App): Promise<NewNoteTemplateChoice | false> {
+	return new Promise((resolve) => {
+		const templates = getTemplateFiles(app);
+		if (templates.length == 0) {
+			new Notice("No templates found");
+			resolve(false);
+			return;
+		}
+		const modal = new NewNoteTemplateSuggestModal(app, templates, resolve);
+		modal.open();
+	});
+}
+
+function getConfiguredNewNoteTemplate(app: App, templatePath: string): TFile | null {
+	const inputPath = normalizePath(templatePath.trim().replace(/^\[\[/, "").replace(/\]\]$/, ""));
+	if (inputPath == "") return null;
+
+	const templateFolder = getCoreTemplatesFolder(app);
+	const candidatePaths = [
+		inputPath,
+		inputPath.endsWith(".md") ? inputPath : `${inputPath}.md`,
+	];
+
+	if (templateFolder != null && templateFolder != "" && !inputPath.startsWith(`${templateFolder}/`)) {
+		candidatePaths.push(
+			`${templateFolder}/${inputPath}`,
+			inputPath.endsWith(".md") ? `${templateFolder}/${inputPath}` : `${templateFolder}/${inputPath}.md`
+		);
+	}
+
+	const file = unique(candidatePaths)
+		.map((path) => app.vault.getAbstractFileByPath(path))
+		.find((file): file is TFile => file instanceof TFile && file.extension == "md");
+
+	if (file == null) {
+		new Notice(`Template not found: ${inputPath}`);
+		return null;
+	}
+
+	return file;
+}
+
+function renderNewNoteTemplate(template: string, expandedTagsAll: string[], expandedTags: string) {
+	const plainTags = expandedTagsAll.filter(e => !isSpecialTag(e));
+	const replacements: Record<string, string> = {
+		expandedTags,
+		tags: expandedTags,
+		tagList: plainTags.join(", "),
+		tagPath: plainTags.join("/"),
+		tagName: plainTags[plainTags.length - 1] ?? "",
+		tagsJson: JSON.stringify(plainTags),
+		tagsYaml: plainTags.map((tag) => `  - ${tag}`).join("\n"),
+	};
+
+	return template.replace(/\{\{(expandedTags|tags|tagList|tagPath|tagName|tagsJson|tagsYaml)\}\}/g, (_, key: keyof typeof replacements) => replacements[key]);
 }
 
 // Thank you @pjeby!
@@ -1251,19 +1411,17 @@ export default class TagFolderPlugin extends Plugin {
 			.join(" ")
 			.trim();
 
+		const selectedTemplate = getConfiguredNewNoteTemplate(this.app, this.settings.newNoteTemplate)
+			?? await askNewNoteTemplate(this.app);
+		if (selectedTemplate === false) return;
+
+		const template = await this.app.vault.read(selectedTemplate);
+		const renderedTemplate = renderNewNoteTemplate(template, expandedTagsAll, expandedTags);
+
 		//@ts-ignore
 		const ww = await this.app.fileManager.createAndOpenMarkdownFile() as TFile;
-		if (this.settings.useFrontmatterTagsForNewNotes) {
-			await this.app.fileManager.processFrontMatter(ww, (matter) => {
-				matter.tags = matter.tags ?? [];
-				matter.tags = expandedTagsAll
-					.filter(e => !isSpecialTag(e))
-					.filter(e => matter.tags.indexOf(e) < 0)
-					.concat(matter.tags);
-			});
-		}
-		else {
-			await this.app.vault.append(ww, expandedTags);
+		if (renderedTemplate.trim() != "") {
+			await this.app.vault.modify(ww, renderedTemplate);
 		}
 	}
 }
@@ -1473,6 +1631,22 @@ class TagFolderSettingTab extends PluginSettingTab {
 						this.plugin.settings.useFrontmatterTagsForNewNotes = value;
 						await this.plugin.saveSettings();
 					});
+			});
+		new Setting(containerEl)
+			.setName("Template for new notes")
+			.setDesc("When set to a valid markdown file path, new notes use this template without opening the template picker. The .md extension is optional.")
+			.addText((text) => {
+				text
+					.setPlaceholder("Templates/New note")
+					.setValue(this.plugin.settings.newNoteTemplate)
+					.onChange(async (value) => {
+						this.plugin.settings.newNoteTemplate = normalizePath(value.trim());
+						await this.plugin.saveSettings();
+					});
+				new NewNoteTemplateInputSuggest(this.app, text.inputEl, (template) => {
+					this.plugin.settings.newNoteTemplate = template.path;
+					void this.plugin.saveSettings();
+				});
 			});
 
 		containerEl.createEl("h2", { text: "Actions" });

--- a/main.ts
+++ b/main.ts
@@ -222,7 +222,7 @@ function askNewNoteTemplate(app: App): Promise<NewNoteTemplateChoice | false> {
 }
 
 function getConfiguredNewNoteTemplate(app: App, templatePath: string): TFile | null {
-	const inputPath = normalizePath(templatePath.trim().replace(/^\[\[/, "").replace(/\]\]$/, ""));
+	const inputPath = normalizeNewNoteTemplatePath(templatePath);
 	if (inputPath == "") return null;
 
 	const templateFolder = getCoreTemplatesFolder(app);
@@ -248,6 +248,13 @@ function getConfiguredNewNoteTemplate(app: App, templatePath: string): TFile | n
 	}
 
 	return file;
+}
+
+function normalizeNewNoteTemplatePath(templatePath: string) {
+	const inputPath = templatePath.trim().replace(/^\[\[/, "").replace(/\]\]$/, "");
+	if (inputPath == "") return "";
+	const normalizedPath = normalizePath(inputPath);
+	return normalizedPath == "/" ? "" : normalizedPath;
 }
 
 function renderNewNoteTemplate(template: string, expandedTagsAll: string[], expandedTags: string) {
@@ -1321,6 +1328,7 @@ export default class TagFolderPlugin extends Plugin {
 			DEFAULT_SETTINGS,
 			await this.loadData()
 		);
+		this.settings.newNoteTemplate = normalizeNewNoteTemplatePath(this.settings.newNoteTemplate);
 		await this.loadTagInfo();
 		tagFolderSetting.set(this.settings);
 		this.compareItems = getCompareMethodItems(this.settings);
@@ -1411,12 +1419,15 @@ export default class TagFolderPlugin extends Plugin {
 			.join(" ")
 			.trim();
 
-		const selectedTemplate = getConfiguredNewNoteTemplate(this.app, this.settings.newNoteTemplate)
-			?? await askNewNoteTemplate(this.app);
+		const configuredTemplatePath = normalizeNewNoteTemplatePath(this.settings.newNoteTemplate);
+		const selectedTemplate = configuredTemplatePath == ""
+			? null
+			: (getConfiguredNewNoteTemplate(this.app, configuredTemplatePath)
+				?? await askNewNoteTemplate(this.app));
 
 		//@ts-ignore
 		const ww = await this.app.fileManager.createAndOpenMarkdownFile() as TFile;
-		if (selectedTemplate !== false) {
+		if (selectedTemplate != null && selectedTemplate !== false) {
 			const template = await this.app.vault.read(selectedTemplate);
 			const renderedTemplate = renderNewNoteTemplate(template, expandedTagsAll, expandedTags);
 			if (renderedTemplate.trim() != "") {
@@ -1653,7 +1664,7 @@ class TagFolderSettingTab extends PluginSettingTab {
 					.setPlaceholder("Templates/New note")
 					.setValue(this.plugin.settings.newNoteTemplate)
 					.onChange(async (value) => {
-						this.plugin.settings.newNoteTemplate = normalizePath(value.trim());
+						this.plugin.settings.newNoteTemplate = normalizeNewNoteTemplatePath(value);
 						await this.plugin.saveSettings();
 					});
 				new NewNoteTemplateInputSuggest(this.app, text.inputEl, (template) => {

--- a/main.ts
+++ b/main.ts
@@ -1413,15 +1413,28 @@ export default class TagFolderPlugin extends Plugin {
 
 		const selectedTemplate = getConfiguredNewNoteTemplate(this.app, this.settings.newNoteTemplate)
 			?? await askNewNoteTemplate(this.app);
-		if (selectedTemplate === false) return;
-
-		const template = await this.app.vault.read(selectedTemplate);
-		const renderedTemplate = renderNewNoteTemplate(template, expandedTagsAll, expandedTags);
 
 		//@ts-ignore
 		const ww = await this.app.fileManager.createAndOpenMarkdownFile() as TFile;
-		if (renderedTemplate.trim() != "") {
-			await this.app.vault.modify(ww, renderedTemplate);
+		if (selectedTemplate !== false) {
+			const template = await this.app.vault.read(selectedTemplate);
+			const renderedTemplate = renderNewNoteTemplate(template, expandedTagsAll, expandedTags);
+			if (renderedTemplate.trim() != "") {
+				await this.app.vault.modify(ww, renderedTemplate);
+			}
+			return;
+		}
+
+		if (this.settings.useFrontmatterTagsForNewNotes) {
+			await this.app.fileManager.processFrontMatter(ww, (matter) => {
+				matter.tags = matter.tags ?? [];
+				matter.tags = expandedTagsAll
+					.filter(e => !isSpecialTag(e))
+					.filter(e => matter.tags.indexOf(e) < 0)
+					.concat(matter.tags);
+			});
+		} else {
+			await this.app.vault.append(ww, expandedTags);
 		}
 	}
 }
@@ -1623,7 +1636,7 @@ class TagFolderSettingTab extends PluginSettingTab {
 			});
 		new Setting(containerEl)
 			.setName("Store tags in frontmatter for new notes")
-			.setDesc("Otherwise, tags are stored with #hashtags at the top of the note")
+			.setDesc("When enabled, tags are written to the note Properties. If no new-note template is selected, TagFolder still creates the note and stores tags here instead of as #hashtags.")
 			.addToggle((toggle) => {
 				toggle
 					.setValue(this.plugin.settings.useFrontmatterTagsForNewNotes)

--- a/types.ts
+++ b/types.ts
@@ -75,6 +75,7 @@ export interface TagFolderSettings {
 	mergeRedundantCombination: boolean;
 	useVirtualTag: boolean;
 	useFrontmatterTagsForNewNotes: boolean,
+	newNoteTemplate: string;
 	doNotSimplifyTags: boolean;
 	overrideTagClicking: boolean;
 	useMultiPaneList: boolean;
@@ -112,6 +113,7 @@ export const DEFAULT_SETTINGS: TagFolderSettings = {
 	mergeRedundantCombination: false,
 	useVirtualTag: false,
 	useFrontmatterTagsForNewNotes: false,
+	newNoteTemplate: "",
 	doNotSimplifyTags: false,
 	overrideTagClicking: false,
 	useMultiPaneList: false,


### PR DESCRIPTION
Allows the "new note in here/as like this" context menu of the TagFolder View to use a template for createNewNote().
A standard template can be set in the plugins settings as described in the updated README.
A template can use e.g. "{{tags}}" as a placeholder for the tag to be inserted.
If no template was specified in the settings, a SuggestModal View will pop up to let the user chose one of the templates inside the templates folder (if it was specified in the core plugins' settings).