### PR TITLE
fix: render core template variables for new notes

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -109,21 +109,31 @@ function getCompareMethodItems(settings: TagFolderSettings) {
 
 type NewNoteTemplateChoice = TFile;
 
-function getCoreTemplatesFolder(app: App): string | null {
+type CoreTemplatesOptions = {
+	folder?: string;
+	templateFolder?: string;
+};
+
+type CoreTemplatesPluginInstance = {
+	options?: CoreTemplatesOptions;
+	insertTemplate?: (template: TFile) => Promise<void> | void;
+};
+
+function getCoreTemplatesPlugin(app: App): CoreTemplatesPluginInstance | null {
 	const internalPlugins = (app as App & {
 		internalPlugins?: {
 			getPluginById?: (id: string) => {
-				instance?: {
-					options?: {
-						folder?: string;
-						templateFolder?: string;
-					};
-				};
+				instance?: CoreTemplatesPluginInstance;
 			};
 		};
 	}).internalPlugins;
-	const templatesPlugin = internalPlugins?.getPluginById?.("templates");
-	const folder = templatesPlugin?.instance?.options?.folder ?? templatesPlugin?.instance?.options?.templateFolder;
+
+	return internalPlugins?.getPluginById?.("templates")?.instance ?? null;
+}
+
+function getCoreTemplatesFolder(app: App): string | null {
+	const options = getCoreTemplatesPlugin(app)?.options;
+	const folder = options?.folder ?? options?.templateFolder;
 	if (!folder) return null;
 	const normalizedFolder = normalizePath(folder);
 	return normalizedFolder == "/" ? "" : normalizedFolder;
@@ -257,7 +267,7 @@ function normalizeNewNoteTemplatePath(templatePath: string) {
 	return normalizedPath == "/" ? "" : normalizedPath;
 }
 
-function renderNewNoteTemplate(template: string, expandedTagsAll: string[], expandedTags: string) {
+function renderTagFolderTemplateVariables(template: string, expandedTagsAll: string[], expandedTags: string) {
 	const plainTags = expandedTagsAll.filter(e => !isSpecialTag(e));
 	const replacements: Record<string, string> = {
 		expandedTags,
@@ -270,6 +280,24 @@ function renderNewNoteTemplate(template: string, expandedTagsAll: string[], expa
 	};
 
 	return template.replace(/\{\{(expandedTags|tags|tagList|tagPath|tagName|tagsJson|tagsYaml)\}\}/g, (_, key: keyof typeof replacements) => replacements[key]);
+}
+
+async function insertNewNoteTemplate(app: App, note: TFile, template: TFile, expandedTagsAll: string[], expandedTags: string) {
+	const templatesPlugin = getCoreTemplatesPlugin(app);
+	const activeMarkdownView = app.workspace.getActiveViewOfType(MarkdownView);
+
+	if (templatesPlugin?.insertTemplate && activeMarkdownView?.file == note) {
+		await templatesPlugin.insertTemplate(template);
+		const editor = activeMarkdownView.editor;
+		editor.setValue(renderTagFolderTemplateVariables(editor.getValue(), expandedTagsAll, expandedTags));
+		return;
+	}
+
+	const templateContent = await app.vault.read(template);
+	const renderedTemplate = renderTagFolderTemplateVariables(templateContent, expandedTagsAll, expandedTags);
+	if (renderedTemplate.trim() != "") {
+		await app.vault.modify(note, renderedTemplate);
+	}
 }
 
 // Thank you @pjeby!
@@ -1428,11 +1456,7 @@ export default class TagFolderPlugin extends Plugin {
 		//@ts-ignore
 		const ww = await this.app.fileManager.createAndOpenMarkdownFile() as TFile;
 		if (selectedTemplate != null && selectedTemplate !== false) {
-			const template = await this.app.vault.read(selectedTemplate);
-			const renderedTemplate = renderNewNoteTemplate(template, expandedTagsAll, expandedTags);
-			if (renderedTemplate.trim() != "") {
-				await this.app.vault.modify(ww, renderedTemplate);
-			}
+			await insertNewNoteTemplate(this.app, ww, selectedTemplate, expandedTagsAll, expandedTags);
 			return;
 		}
 


### PR DESCRIPTION
<img width="678" height="404" alt="85635" src="https://github.com/user-attachments/assets/d1c7347b-ae06-48c7-afbd-73ad027a0af0" />
obsidian template variables such as {{date}} would not get replace properly before, but now do:
<img width="540" height="396" alt="73993" src="https://github.com/user-attachments/assets/a06064f9-c378-432e-ae3a-3350633ddb67" />
