### PR TITLE
Settings overhaul

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,63 +56,127 @@ When using this filter, this plugin shows only "Pear" (Sweet but not red) and "T
 
 ### Settings
 
-#### Behavior
+The settings are organized by the job you are trying to do:
 
-##### Always Open
+- **Startup**: launch behavior.
+- **Quick setup**: apply a common layout first, then fine-tune individual settings.
+- **Simplify tree paths**: cleanup for repeated parents, redundant combinations, and intermediate levels.
+- **Tag nesting and file rows**: controls for nested tags, duplicate files, and untagged or unlinked notes.
+- **File display**: how files are named and sorted inside each folder.
+- **Tag folder display**: tag sorting and virtual tags.
+- **Pinned tags and aliases**: pinned tag order, custom tag marks, aliases, and redirects.
+- **New notes and templates**: how TagFolder creates notes from the tag tree.
+- **Filters**: which folders, notes, and tags are included.
+- **Actions and panes**: click behavior and where file lists open.
+- **Link folder**: incoming and outgoing link-tree behavior.
+- **Advanced**: performance, drag behavior, and bug-report helpers.
+
+#### Which setting do I want?
+
+| Goal | Setting |
+| ---- | ------- |
+| Parent folders show the same note repeatedly | Tag nesting and file rows -> Duplicate file visibility -> Hide all parent duplicates |
+| Show every note in every matching parent and sub-folder | Tag nesting and file rows -> Duplicate file visibility -> Show parent and child |
+| Make `#a/b` behave like `#a` plus `#b` | Tag nesting and file rows -> Split nested tags |
+| Let separate tags like `#a #b` appear as `#a -> #b` | Tag nesting and file rows -> Nest separate tags |
+| Use a template when creating notes from TagFolder | New notes and templates -> Template |
+| Browse notes by links instead of tags | Press `Ctrl+P` and run **Show Link Folder** |
+
+#### Startup
+
+##### Open TagFolder on startup
 
 Place TagFolder on the left pane and activate it at every Obsidian launch.
 
-##### Use pinning
-We can pin the tag if we enable this option.  
-When this feature is enabled, the pin information is saved in the file set in the next configuration.  
-Pinned tags are sorted according to `key` in the frontmatter of `taginfo.md`.
+#### Quick setup
 
-##### Pin information file
-We can change the name of the file in which pin information is saved.
-This can be configured also from the context-menu.
+##### Choose a starting layout
 
-| Item     | Meaning of the value                                                                              |
-| -------- | ------------------------------------------------------------------------------------------------- |
-| key      | If exists, the tag is pinned.                                                                     |
-| mark     | The label which is shown instead of `📌`.                                                          |
-| alt      | The tag will be shown as this. But they will not be merged into the same one. No `#` is required. |
-| redirect | The tag will be redirected to the configured one and will be merged. No `#` is required.          |
+Use these presets when you are not sure which detailed settings you need.
 
-##### Disable narrowing down
-TagFolder creates the folder structure by collecting combinations of tags that are used in the same note, to make it easier for us to find notes.
-When this feature is enabled, collected combinations are no longer structured and show as we have organized them in a manner.
+- **Clean nested tree**: keeps nested tags as folders and shows each file only in the deepest sub-folder. Use this if parent tags show the same note repeatedly.
+- **Show every match**: shows files at every matching tag level. Use this if you want parent folders to list everything under them.
+- **Split nested tags**: treats a nested tag like `#a/b` as two separate tags: `#a` and `#b`.
 
+#### Simplify tree paths
 
-#### Files
+##### Merge redundant combinations
+Merge equivalent tag combinations, such as `#a/b` and `#b/a`, when there is no intermediate folder to show.
 
-##### Display Method
+##### Keep intermediate levels
+Keep single-note paths expanded instead of collapsing them. Example: keep `#a -> #b` instead of showing `#a/#b` as one row.
 
-You can configure how the entry shows.
+##### Advanced: merge repeated parents
 
-##### Order method
+Use this when one note has multiple related nested tags, such as `#a/b` and `#a/c`.
+
+When enabled, TagFolder avoids showing `#a` again inside the existing `#a` branch.
+
+#### Tag nesting and file rows
+
+##### Duplicate file visibility
+
+Control whether files already shown in sub-folders also appear in their parent folders.
+
+- **Show parent and child**: `#a/b` appears under both `#a` and `#a/b`.
+- **Hide nested-tag parents**: `#a/b` appears only under `#a/b`, but `#a + #b` can still appear under both `#a` and `#a -> #b`.
+- **Hide all parent duplicates**: hide parent rows whenever the same file appears in a child folder.
+
+The middle option only matters when intermediate levels can be collapsed. If **Keep intermediate levels** is enabled, it is hidden because it has no meaningful effect.
+
+##### Nest separate tags
+
+When enabled, separate tags on the same note can form nested paths. For example, a note tagged `#a` and `#b` can appear under `#a -> #b`, even though those are two separate tags.
+
+Turn this off to stop those separate-tag nesting paths and show each matching tag group more directly.
+
+This does **not** split nested tags. A tag written as `#a/b` still behaves like a nested tag. Use **Split nested tags** if you want `#a/b` to behave like `#a` plus `#b`.
+
+##### Split nested tags
+
+If you enable this option, every nested tag is split into normal tags.
+
+`#a/b` will be treated like `#a` and `#b`.
+
+##### Group untagged/unlinked notes
+
+Show untagged notes inside the special untagged folder, and unlinked notes inside the special unlinked folder, instead of as direct root-level file rows.
+
+#### File display
+
+##### Label
+
+Choose whether file rows show the name, path, or both.
+
+##### Sort order
 
 You can order items by:
-- Displaying name
+- Label
 - Filename
 - Modified time
-- Fullpath of the file
+- Created time
+- Full file path
 
-##### Use title
+##### Sort exact folder matches first
 
-When you enable this option, the value in the frontmatter or first level one heading will be shown instead of `NAME`.
+When enabled, files that belong directly to the current folder are sorted before files that also appear in sub-folders. This prioritizes parent-folder matches but still keeps duplicate sub-folder matches visible.
 
-##### Frontmatter path
-Dotted path to retrieve title from frontmatter.
+##### Prefer Properties title
 
-#### Tags
+When enabled, the configured Properties value is shown when available. If it is missing, TagFolder falls back to the first H1 heading, then the file name.
 
-##### Order method
+##### Properties title path
+Dotted path to retrieve the title from Properties. This setting is only enabled when **Prefer Properties title** is enabled.
+
+#### Tag folder display
+
+##### Sort order
 
 You can order tags by:
-- Filename
-- Count of items
+- Tag name
+- Number of files
 
-##### Use virtual tags
+##### Virtual freshness tags
 
 When we enable this feature, our notes will be tagged as their freshness automatically.
 | Icon | Edited ...            |
@@ -123,172 +187,124 @@ When we enable this feature, our notes will be tagged as their freshness automat
 | 📚    | Within 7 days         |
 | 🗄    | Older than 7 days ago |
 
-##### Display folder as tag
+##### Vault folders as tags
 
 When we enable this feature, the folder will be shown as a tag.
 
-##### Store tags in frontmatter for new notes
+#### Pinned tags and aliases
 
-This setting changes how tags are stored in new notes created by TagFolder. When disabled, tags are stored as #hashtags at the top of new notes. When enabled, tags are stored in the frontmatter and displayed in the note's Properties.
+##### Enable tag metadata
 
-##### Template for new notes
+Pinning lets you keep important tags near the top of the tag tree. When this setting is enabled, TagFolder reads tag metadata from the configured pin information file. Any tag entry with a `key` value is pinned and sorted before unpinned tags. The `key` is also the order key, so lower or alphabetically earlier keys appear first.
 
-When this setting is set to a valid markdown template path, TagFolder uses that template immediately when creating a new note from the tag tree. The `.md` extension is optional. If the setting is empty or invalid, TagFolder opens a template picker.
+Pinning does not change the tags in your notes. It only changes how tags are displayed and sorted in TagFolder.
+
+##### Metadata file
+
+Markdown file used to store tag metadata. You can also create or update entries from the tag context menu.
+
+| Item     | Meaning of the value                                                                              |
+| -------- | ------------------------------------------------------------------------------------------------- |
+| key      | If set, the tag is pinned. The value controls pinned-tag order.                                    |
+| mark     | The label shown next to the tag instead of `📌`.                                                   |
+| alt      | The tag will be shown as this. But they will not be merged into the same one. No `#` is required. |
+| redirect | The tag will be redirected to the configured one and will be merged. No `#` is required.          |
+
+#### New notes and templates
+
+##### Store tags in Properties
+
+This setting changes how tags are stored in new notes created by TagFolder when no template is used. When disabled, tags are stored as #hashtags at the top of new notes. When enabled, tags are stored in Properties.
+
+##### Template
+
+When this setting is set to a valid markdown template path, TagFolder uses that template immediately when creating a new note from the tag tree. The `.md` extension is optional. If the setting is empty, TagFolder creates a plain note using the setting above.
 
 Templates can include these placeholders, which are replaced with the tags from the clicked location:
 
 | Placeholder        | Replacement                         |
 | ------------------ | ----------------------------------- |
-| `{{expandedTags}}` or `{{tags}}` | Tags as hashtags, e.g. `#tag1 #tag2` |
-| `{{tagList}}`      | Tags as comma-separated text, e.g. `tag1, tag2` |
-| `{{tagPath}}`      | Tags as a slash-separated path, e.g. `tag1/tag2` |
+| `{{expandedTags}}` or `{{tags}}` | Tags as hashtags, e.g. `#a #b` |
+| `{{tagList}}`      | Tags as comma-separated text, e.g. `a, b` |
+| `{{tagPath}}`      | Tags as a slash-separated path, e.g. `a/b` |
 | `{{tagName}}`      | The last tag in the clicked context |
 | `{{tagsJson}}`     | Tags as a JSON array                |
 | `{{tagsYaml}}`     | Tags as YAML list lines             |
 
-#### Actions
+#### Filters
 
-##### Search tags inside TagFolder when clicking tags
+In this section, **vault folders** means real Obsidian folders that contain your notes, such as `Projects/ClientA`. **Tag folders** means the generated TagFolder tree created from tags, such as `#a -> #a/b`.
+
+##### Vault folders - only include
+Only index notes whose real vault path starts with one of these comma-separated folders. This does not filter generated tag folders.
+
+##### Vault folders - exclude
+
+Skip notes whose real vault path starts with one of these comma-separated folders. This does not hide generated tag folders.
+
+##### Tag folders - exclude notes
+
+Remove the whole note from TagFolder if it has any of these comma-separated tags. For example, if a note has `#a` and `#c`, and `#c` is excluded here, the note is not shown under `#a`, `#c`, or any other tag.
+
+##### Tag folders - hide tags
+
+Remove these comma-separated tags from the generated tree, but keep each note under its remaining tags. For example, if a note has `#a` and `#c`, and `#c` is hidden here, the note can still appear under `#a`.
+
+##### Tag folders - archive tags
+Show notes with these comma-separated tags under the matching generated tag folder instead of their other top-level tag folders. For example, if a note has `#a` and `#c`, and `#c` is archived here, the note is grouped under `#c` instead of `#a`.
+
+#### Actions and panes
+
+##### Tag clicks
 We can search tags inside TagFolder when clicking tags instead of opening the default search pane.
 With control and shift keys, we can remove the tag from the search condition or add an exclusion of it to that.
 
-##### List files in a separated pane
+##### Separate file-list pane
 When enabled, files will be shown in a separated pane.
 
-#### Arrangements
+##### Open file list in
 
-##### Hide Items
+Choose where newly opened file-list panes appear.
 
-Configure hiding items.
-- Hide nothing
-- Only intermediates of nested tags
-- All intermediates
+#### Link folder
 
-If you have these items:
-```
-2021-11-01 : #daily/2021/11 #status/summarized
-2021-11-02 : #daily/2021/11 #status/summarized
-2021-11-03 : #daily/2021/11 #status/jot
-2021-12-01 : #daily/2021/12 #status/jot
-```
+##### Open
 
-This setting affects as like below.
-- Hide nothing
+Link Folder is a separate pane from Tag Folder. Press `Ctrl+P` and run **Show Link Folder** to open it. You can also use the **Open** button in the Link folder settings section.
 
-```
-daily
-	→ 2021
-		→ 11
-			status
-				→ jot
-					2021-11-03
-				→ summarized
-					2021-11-01
-					2021-11-02
-				2021-11-01
-				2021-11-02
-				2021-11-03
-			2021-11-01
-			2021-11-02
-			2021-11-03
-		2021-11-01
-		2021-11-02
-		2021-11-03
-		2021-12-01
-		→ 12
-			:
-	2021-11-01
-	2021-11-02
-	2021-11-03
-	2021-12-01
-```
+Tag Folder builds a tree from note tags. Link Folder builds a similar tree from note links:
 
-- Only intermediates of nested tags
-Hide only intermediates of nested tags, so show items only on the last or break of the nested tags.
-```
-daily
-	→ 2021
-		→ 11
-			status
-				→ jot
-					2021-11-03
-				→ summarized
-					2021-11-01
-					2021-11-02
-			2021-11-01
-			2021-11-02
-			2021-11-03
-		→ 12
-			:
-```
-- All intermediates
-Hide all intermediates, so show items only deepest.
-```
-daily
-	→ 2021
-		→ 11
-			status
-				→ jot
-					2021-11-03
-				→ summarized
-					2021-11-01
-					2021-11-02
-		→ 12
-			:
-```
+- Incoming links are backlinks: notes that link to the current note.
+- Outgoing links are notes that the current note links to.
 
-##### Merge redundant combinations
-When this feature is enabled, a/b and b/a are merged into a/b if there are no intermediates.
+##### Use incoming
 
-##### Do not simplify empty folders
-Keep empty folders, even if they can be simplified.
+Include backlinks: notes that link to the current note.
 
-##### Do not treat nested tags as dedicated levels
+##### Use outgoing
 
-If you enable this option, every nested tag is split into normal tags.
+Include outgoing links: notes that the current note links to.
 
-`#dev/TagFolder` will be treated like `#dev` and `#TagFolder`.
+##### Hide indirect notes
 
-##### Reduce duplicated parents in nested tags
+Show only first-degree linked notes. Hide notes that are reached only through another linked note.
 
-If we have the doc (e.g., `example note`) with nested tags which have the same parents, like `#topic/calculus`, `#topic/electromagnetics`:
+##### Combine related branches
 
-- Disabled
-```
-topic
-	 - > calculus
-		 topic
-			   - > electromagnetics
-				   example note
-		 example note 
-```
-- Enabled
-```
-topic
-	 - > calculus
-		  - > electromagnetics
-			  example note
-		 example note 
-```
+When link branches share notes, combine them into one connected tree instead of showing separate duplicate branches.
 
-#### Filters
+#### Advanced
 
+##### Tag scanning delay
 
-##### Target Folders
-If we set this, the plugin will only target files in it.
+Delay in milliseconds before metadata changes are reflected in the tag tree. Plugin reload is required.
 
+##### Disable tag dragging
 
-##### Ignore Folders
+Turn this off if drag-and-drop tag movement causes problems. This feature uses Obsidian internal APIs.
 
-Ignore documents in specific folders.
+#### Utilities
 
+##### Copy tags for bug reports
 
-##### Ignore note Tag
-
-If the note has the tag that is set in here, the note would be treated as there was not.
-
-##### Ignore Tag
-
-Tags that were set here would be treated as there were not.
-
-##### Archive tags
+Copy the current tag data for a GitHub issue. Use disguised tags if the real tag names are private.

--- a/main.ts
+++ b/main.ts
@@ -74,7 +74,6 @@ const HideItemsType: Record<string, string> = {
 	ALL_EXCEPT_BOTTOM: "All intermediates",
 };
 
-
 function dotted<T extends Record<string, any>>(object: T, notation: string) {
 	return notation.split('.').reduce((a, b) => (a && (b in a)) ? a[b] : null, object);
 }
@@ -1466,10 +1465,15 @@ class TagFolderSettingTab extends PluginSettingTab {
 		const { containerEl } = this;
 		containerEl.empty();
 
-		containerEl.createEl("h2", { text: "Behavior" });
+		const refreshAfterSettingChange = () => {
+			this.plugin.loadFileInfo();
+			this.display();
+		};
+
+		containerEl.createEl("h2", { text: "Startup" });
 		new Setting(containerEl)
 			.setName("Always Open")
-			.setDesc("Place TagFolder on the left pane and activate it at every Obsidian launch")
+			.setDesc("Automatically open TagFolder in the left sidebar when Obsidian starts.")
 			.addToggle((toggle) =>
 				toggle
 					.setValue(this.plugin.settings.alwaysOpen)
@@ -1478,54 +1482,144 @@ class TagFolderSettingTab extends PluginSettingTab {
 						await this.plugin.saveSettings();
 					})
 			);
+
+		containerEl.createEl("h2", { text: "Quick setup" });
 		new Setting(containerEl)
-			.setName("Use pinning")
+			.setName("Choose a starting layout")
+			.setDesc("Apply a common TagFolder layout. You can still adjust every setting below afterwards.")
+			.addButton((button) =>
+				button
+					.setButtonText("Clean nested tree")
+					.onClick(async () => {
+						this.plugin.settings.disableNarrowingDown = false;
+						this.plugin.settings.disableNestedTags = false;
+						this.plugin.settings.hideItems = "ALL_EXCEPT_BOTTOM";
+						this.plugin.settings.reduceNestedParent = true;
+						this.plugin.settings.mergeRedundantCombination = false;
+						await this.plugin.saveSettings();
+						refreshAfterSettingChange();
+					})
+			)
+			.addButton((button) =>
+				button
+					.setButtonText("Show every match")
+					.onClick(async () => {
+						this.plugin.settings.disableNarrowingDown = false;
+						this.plugin.settings.disableNestedTags = false;
+						this.plugin.settings.hideItems = "NONE";
+						this.plugin.settings.reduceNestedParent = true;
+						this.plugin.settings.mergeRedundantCombination = false;
+						await this.plugin.saveSettings();
+						refreshAfterSettingChange();
+					})
+			)
+			.addButton((button) =>
+				button
+					.setButtonText("Split nested tags")
+					.onClick(async () => {
+						this.plugin.settings.disableNarrowingDown = false;
+						this.plugin.settings.disableNestedTags = true;
+						this.plugin.settings.hideItems = "NONE";
+						await this.plugin.saveSettings();
+						refreshAfterSettingChange();
+					})
+		);
+
+		containerEl.createEl("h2", { text: "Simplify tree paths" });
+		new Setting(containerEl)
+			.setName("Merge redundant combinations")
 			.setDesc(
-				"When this feature is enabled, the pin information is saved in the file set in the next configuration."
+				"Merge equivalent tag combinations, such as #a/b and #b/a, when there is no intermediate folder to show."
 			)
 			.addToggle((toggle) => {
 				toggle
-					.setValue(this.plugin.settings.useTagInfo)
+					.setValue(this.plugin.settings.mergeRedundantCombination)
 					.onChange(async (value) => {
-						this.plugin.settings.useTagInfo = value;
-						if (this.plugin.settings.useTagInfo) {
-							await this.plugin.loadTagInfo();
-						}
+						this.plugin.settings.mergeRedundantCombination = value;
 						await this.plugin.saveSettings();
-						pi.setDisabled(!value);
 					});
 			});
-		const pi = new Setting(containerEl)
-			.setName("Pin information file")
-			.setDisabled(!this.plugin.settings.useTagInfo)
-			.addText((text) => {
-				text
-					.setValue(this.plugin.settings.tagInfo)
+		new Setting(containerEl)
+			.setName("Keep intermediate levels")
+			.setDesc(
+				"Keep single-note paths expanded instead of collapsing them. Example: keep #a -> #b instead of showing #a/#b as one row."
+			)
+			.addToggle((toggle) => {
+				toggle
+					.setValue(this.plugin.settings.doNotSimplifyTags)
 					.onChange(async (value) => {
-						this.plugin.settings.tagInfo = value;
-						if (this.plugin.settings.useTagInfo) {
-							await this.plugin.loadTagInfo();
+						this.plugin.settings.doNotSimplifyTags = value;
+						await this.plugin.saveSettings();
+						refreshAfterSettingChange();
+					});
+			});
+		new Setting(containerEl)
+			.setName("Advanced: merge repeated parents")
+			.setDesc("For notes with related nested tags like #a/b and #a/c, avoid showing #a again inside the #a branch.")
+			.addToggle((toggle) => {
+				toggle
+					.setValue(this.plugin.settings.reduceNestedParent)
+					.onChange(async (value) => {
+						this.plugin.settings.reduceNestedParent = value;
+						await this.plugin.saveSettings();
+					});
+			});
+
+		containerEl.createEl("h2", { text: "Tag nesting and file rows" });
+		new Setting(containerEl)
+			.setName("Hide Items")
+			.setDesc("Hide items on the landing or nested tags")
+			.addDropdown((dd) => {
+				dd.addOptions(HideItemsType)
+					.setValue(this.plugin.settings.hideItems)
+					.onChange(async (key) => {
+						if (
+							key == "NONE" ||
+							key == "DEDICATED_INTERMIDIATES" ||
+							key == "ALL_EXCEPT_BOTTOM"
+						) {
+							this.plugin.settings.hideItems = key;
 						}
 						await this.plugin.saveSettings();
 					});
 			});
 		new Setting(containerEl)
 			.setName("Disable narrowing down")
-			.setDesc(
-				"When this feature is enabled, relevant tags will be shown with the title instead of making a sub-structure."
-			)
+			.setDesc("Disable narrowing down tags")
 			.addToggle((toggle) => {
 				toggle
-					.setValue(this.plugin.settings.disableNarrowingDown)
+					.setValue(!this.plugin.settings.disableNarrowingDown)
 					.onChange(async (value) => {
-						this.plugin.settings.disableNarrowingDown = value;
+						this.plugin.settings.disableNarrowingDown = !value;
 						await this.plugin.saveSettings();
 					});
 			});
-		containerEl.createEl("h2", { text: "Files" });
 		new Setting(containerEl)
-			.setName("Display method")
-			.setDesc("How to show a title of files")
+			.setName("Do not treat nested tags as dedicated levels")
+			.setDesc("Treat nested tags as normal tags")
+			.addToggle((toggle) => {
+				toggle
+					.setValue(this.plugin.settings.disableNestedTags)
+					.onChange(async (value) => {
+						this.plugin.settings.disableNestedTags = value;
+						await this.plugin.saveSettings();
+					});
+			});
+		new Setting(containerEl)
+			.setName("Keep untagged items on the root")
+			.addToggle((toggle) => {
+				toggle
+					.setValue(!this.plugin.settings.expandUntaggedToRoot)
+					.onChange(async (value) => {
+						this.plugin.settings.expandUntaggedToRoot = !value;
+						await this.plugin.saveSettings();
+					});
+			});
+
+		containerEl.createEl("h2", { text: "File display" });
+		new Setting(containerEl)
+			.setName("Display Method")
+			.setDesc("You can configure how the entry shows.")
 			.addDropdown((dropdown) =>
 				dropdown
 					.addOptions({
@@ -1563,8 +1657,8 @@ class TagFolderSettingTab extends PluginSettingTab {
 					.onChange((order) => setOrderMethod(undefined, order));
 			});
 		new Setting(containerEl)
-			.setName("Prioritize items which are not contained in sub-folder")
-			.setDesc("If this has been enabled, the items which have no more extra tags are first.")
+			.setName("Sort exact items first")
+			.setDesc("Sort items that belong exactly to the folder before items that are shown in sub-folders.")
 			.addToggle((toggle) => {
 				toggle
 					.setValue(this.plugin.settings.sortExactFirst)
@@ -1599,7 +1693,7 @@ class TagFolderSettingTab extends PluginSettingTab {
 					});
 			});
 
-		containerEl.createEl("h2", { text: "Tags" });
+		containerEl.createEl("h2", { text: "Tag folder display" });
 
 		const setOrderMethodTag = async (key?: string, order?: string) => {
 			const oldSetting = this.plugin.settings.sortTypeTag.split("_");
@@ -1645,6 +1739,41 @@ class TagFolderSettingTab extends PluginSettingTab {
 						await this.plugin.saveSettings();
 					});
 			});
+
+		containerEl.createEl("h2", { text: "Pinned tags and aliases" });
+		new Setting(containerEl)
+			.setName("Use pinning")
+			.setDesc(
+				"Pin tags using metadata from the pin information file."
+			)
+			.addToggle((toggle) => {
+				toggle
+					.setValue(this.plugin.settings.useTagInfo)
+					.onChange(async (value) => {
+						this.plugin.settings.useTagInfo = value;
+						if (this.plugin.settings.useTagInfo) {
+							await this.plugin.loadTagInfo();
+						}
+						await this.plugin.saveSettings();
+						pi.setDisabled(!value);
+					});
+			});
+		const pi = new Setting(containerEl)
+			.setName("Pin information file")
+			.setDisabled(!this.plugin.settings.useTagInfo)
+			.addText((text) => {
+				text
+					.setValue(this.plugin.settings.tagInfo)
+					.onChange(async (value) => {
+						this.plugin.settings.tagInfo = value;
+						if (this.plugin.settings.useTagInfo) {
+							await this.plugin.loadTagInfo();
+						}
+						await this.plugin.saveSettings();
+					});
+			});
+
+		containerEl.createEl("h2", { text: "New notes and templates" });
 		new Setting(containerEl)
 			.setName("Store tags in frontmatter for new notes")
 			.setDesc("When enabled, tags are written to the note Properties. If no new-note template is selected, TagFolder still creates the note and stores tags here instead of as #hashtags.")
@@ -1672,165 +1801,6 @@ class TagFolderSettingTab extends PluginSettingTab {
 					void this.plugin.saveSettings();
 				});
 			});
-
-		containerEl.createEl("h2", { text: "Actions" });
-		new Setting(containerEl)
-			.setName("Search tags inside TagFolder when clicking tags")
-			.addToggle((toggle) => {
-				toggle
-					.setValue(this.plugin.settings.overrideTagClicking)
-					.onChange(async (value) => {
-						this.plugin.settings.overrideTagClicking = value;
-						await this.plugin.saveSettings();
-					});
-			});
-		new Setting(containerEl)
-			.setName("List files in a separated pane")
-			.addToggle((toggle) => {
-				toggle
-					.setValue(this.plugin.settings.useMultiPaneList)
-					.onChange(async (value) => {
-						this.plugin.settings.useMultiPaneList = value;
-						await this.plugin.saveSettings();
-					});
-			});
-		new Setting(containerEl)
-			.setName("Show list in")
-			.setDesc("This option applies to the newly opened list")
-			.addDropdown((dropdown) => {
-				dropdown
-					.addOptions(enumShowListIn)
-					.setValue(this.plugin.settings.showListIn)
-					.onChange(async (value) => {
-						this.plugin.settings.showListIn = value as keyof typeof enumShowListIn;
-						await this.plugin.saveSettings();
-					});
-			});
-		containerEl.createEl("h2", { text: "Arrangements" });
-
-		new Setting(containerEl)
-			.setName("Hide Items")
-			.setDesc("Hide items on the landing or nested tags")
-			.addDropdown((dd) => {
-				dd.addOptions(HideItemsType)
-					.setValue(this.plugin.settings.hideItems)
-					.onChange(async (key) => {
-						if (
-							key == "NONE" ||
-							key == "DEDICATED_INTERMIDIATES" ||
-							key == "ALL_EXCEPT_BOTTOM"
-						) {
-							this.plugin.settings.hideItems = key;
-						}
-						await this.plugin.saveSettings();
-					});
-			});
-		new Setting(containerEl)
-			.setName("Merge redundant combinations")
-			.setDesc(
-				"When this feature is enabled, a/b and b/a are merged into a/b if there is no intermediates."
-			)
-			.addToggle((toggle) => {
-				toggle
-					.setValue(this.plugin.settings.mergeRedundantCombination)
-					.onChange(async (value) => {
-						this.plugin.settings.mergeRedundantCombination = value;
-						await this.plugin.saveSettings();
-					});
-			});
-		new Setting(containerEl)
-			.setName("Do not simplify empty folders")
-			.setDesc(
-				"Keep empty folders, even if they can be simplified."
-			)
-			.addToggle((toggle) => {
-				toggle
-					.setValue(this.plugin.settings.doNotSimplifyTags)
-					.onChange(async (value) => {
-						this.plugin.settings.doNotSimplifyTags = value;
-						await this.plugin.saveSettings();
-					});
-			});
-
-		new Setting(containerEl)
-			.setName("Do not treat nested tags as dedicated levels")
-			.setDesc("Treat nested tags as normal tags")
-			.addToggle((toggle) => {
-				toggle
-					.setValue(this.plugin.settings.disableNestedTags)
-					.onChange(async (value) => {
-						this.plugin.settings.disableNestedTags = value;
-						await this.plugin.saveSettings();
-					});
-			});
-		new Setting(containerEl)
-			.setName("Reduce duplicated parents in nested tags")
-			.setDesc("If enabled, #web/css, #web/javascript will merged into web -> css -> javascript")
-			.addToggle((toggle) => {
-				toggle
-					.setValue(this.plugin.settings.reduceNestedParent)
-					.onChange(async (value) => {
-						this.plugin.settings.reduceNestedParent = value;
-						await this.plugin.saveSettings();
-					});
-			});
-
-		new Setting(containerEl)
-			.setName("Keep untagged items on the root")
-			.addToggle((toggle) => {
-				toggle
-					.setValue(this.plugin.settings.expandUntaggedToRoot)
-					.onChange(async (value) => {
-						this.plugin.settings.expandUntaggedToRoot = value;
-						await this.plugin.saveSettings();
-					});
-			});
-
-		containerEl.createEl("h2", { text: "Link Folder" });
-		new Setting(containerEl)
-			.setName("Use Incoming")
-			.setDesc("")
-			.addToggle((toggle) =>
-				toggle
-					.setValue(this.plugin.settings.linkConfig.incoming.enabled)
-					.onChange(async (value) => {
-						this.plugin.settings.linkConfig.incoming.enabled = value;
-						await this.plugin.saveSettings();
-					})
-			);
-		new Setting(containerEl)
-			.setName("Use Outgoing")
-			.setDesc("")
-			.addToggle((toggle) =>
-				toggle
-					.setValue(this.plugin.settings.linkConfig.outgoing.enabled)
-					.onChange(async (value) => {
-						this.plugin.settings.linkConfig.outgoing.enabled = value;
-						await this.plugin.saveSettings();
-					})
-			);
-		new Setting(containerEl)
-			.setName("Hide indirectly linked notes")
-			.setDesc("")
-			.addToggle((toggle) =>
-				toggle
-					.setValue(this.plugin.settings.linkShowOnlyFDR)
-					.onChange(async (value) => {
-						this.plugin.settings.linkShowOnlyFDR = value;
-						await this.plugin.saveSettings();
-					})
-			);
-		new Setting(containerEl)
-			.setName("Connect linked tree")
-			.setDesc("")
-			.addToggle((toggle) =>
-				toggle
-					.setValue(this.plugin.settings.linkCombineOtherTree)
-					.onChange(async (value) => {
-						this.plugin.settings.linkCombineOtherTree = value;
-						await this.plugin.saveSettings();
-					})
-			);
 
 		containerEl.createEl("h2", { text: "Filters" });
 		new Setting(containerEl)
@@ -1896,7 +1866,97 @@ class TagFolderSettingTab extends PluginSettingTab {
 					})
 			);
 
-		containerEl.createEl("h2", { text: "Misc" });
+		containerEl.createEl("h2", { text: "Actions and panes" });
+		new Setting(containerEl)
+			.setName("Search tags inside TagFolder when clicking tags")
+			.addToggle((toggle) => {
+				toggle
+					.setValue(this.plugin.settings.overrideTagClicking)
+					.onChange(async (value) => {
+						this.plugin.settings.overrideTagClicking = value;
+						await this.plugin.saveSettings();
+					});
+			});
+		new Setting(containerEl)
+			.setName("List files in a separated pane")
+			.addToggle((toggle) => {
+				toggle
+					.setValue(this.plugin.settings.useMultiPaneList)
+					.onChange(async (value) => {
+						this.plugin.settings.useMultiPaneList = value;
+						await this.plugin.saveSettings();
+					});
+			});
+		new Setting(containerEl)
+			.setName("Show list in")
+			.setDesc("This option applies to the newly opened list")
+			.addDropdown((dropdown) => {
+				dropdown
+					.addOptions(enumShowListIn)
+					.setValue(this.plugin.settings.showListIn)
+					.onChange(async (value) => {
+						this.plugin.settings.showListIn = value as keyof typeof enumShowListIn;
+						await this.plugin.saveSettings();
+					});
+			});
+
+		containerEl.createEl("h2", { text: "Link folder" });
+		new Setting(containerEl)
+			.setName("Open")
+			.setDesc("Press Ctrl+P and run `Show Link Folder` to open this separate pane. It builds a folder-like tree from note links instead of tags.")
+			.addButton((button) =>
+				button
+					.setButtonText("Open")
+					.onClick(() => {
+						void this.plugin.activateViewLink();
+					})
+			);
+		new Setting(containerEl)
+			.setName("Use Incoming")
+			.setDesc("")
+			.addToggle((toggle) =>
+				toggle
+					.setValue(this.plugin.settings.linkConfig.incoming.enabled)
+					.onChange(async (value) => {
+						this.plugin.settings.linkConfig.incoming.enabled = value;
+						await this.plugin.saveSettings();
+					})
+			);
+		new Setting(containerEl)
+			.setName("Use Outgoing")
+			.setDesc("")
+			.addToggle((toggle) =>
+				toggle
+					.setValue(this.plugin.settings.linkConfig.outgoing.enabled)
+					.onChange(async (value) => {
+						this.plugin.settings.linkConfig.outgoing.enabled = value;
+						await this.plugin.saveSettings();
+					})
+			);
+		new Setting(containerEl)
+			.setName("Hide indirectly linked notes")
+			.setDesc("")
+			.addToggle((toggle) =>
+				toggle
+					.setValue(this.plugin.settings.linkShowOnlyFDR)
+					.onChange(async (value) => {
+						this.plugin.settings.linkShowOnlyFDR = value;
+						await this.plugin.saveSettings();
+					})
+			);
+		new Setting(containerEl)
+			.setName("Connect linked tree")
+			.setDesc("")
+			.addToggle((toggle) =>
+				toggle
+					.setValue(this.plugin.settings.linkCombineOtherTree)
+					.onChange(async (value) => {
+						this.plugin.settings.linkCombineOtherTree = value;
+						await this.plugin.saveSettings();
+					})
+			);
+
+		containerEl.createEl("h2", { text: "Advanced" });
 
 		new Setting(containerEl)
 			.setName("Tag scanning delay")

--- a/main.ts
+++ b/main.ts
@@ -69,10 +69,18 @@ export type DISPLAY_METHOD = "PATH/NAME" | "NAME" | "NAME : PATH";
 export type HIDE_ITEMS_TYPE = "NONE" | "DEDICATED_INTERMIDIATES" | "ALL_EXCEPT_BOTTOM";
 
 const HideItemsType: Record<string, string> = {
-	NONE: "Hide nothing",
-	DEDICATED_INTERMIDIATES: "Only intermediates of nested tags",
-	ALL_EXCEPT_BOTTOM: "All intermediates",
+	NONE: "Show parent and child",
+	DEDICATED_INTERMIDIATES: "Hide nested-tag parents",
+	ALL_EXCEPT_BOTTOM: "Hide all parent duplicates",
 };
+
+function getVisibleHideItemsType(doNotSimplifyTags: boolean): Record<string, string> {
+	if (!doNotSimplifyTags) return HideItemsType;
+	return Object.fromEntries(
+		Object.entries(HideItemsType).filter(([key]) => key != "DEDICATED_INTERMIDIATES")
+	);
+}
+
 
 function dotted<T extends Record<string, any>>(object: T, notation: string) {
 	return notation.split('.').reduce((a, b) => (a && (b in a)) ? a[b] : null, object);
@@ -1472,7 +1480,7 @@ class TagFolderSettingTab extends PluginSettingTab {
 
 		containerEl.createEl("h2", { text: "Startup" });
 		new Setting(containerEl)
-			.setName("Always Open")
+			.setName("Open TagFolder on startup")
 			.setDesc("Automatically open TagFolder in the left sidebar when Obsidian starts.")
 			.addToggle((toggle) =>
 				toggle
@@ -1566,26 +1574,29 @@ class TagFolderSettingTab extends PluginSettingTab {
 			});
 
 		containerEl.createEl("h2", { text: "Tag nesting and file rows" });
+		const visibleHideItemsType = getVisibleHideItemsType(this.plugin.settings.doNotSimplifyTags);
+		const visibleHideItemsValue =
+			this.plugin.settings.doNotSimplifyTags && this.plugin.settings.hideItems == "DEDICATED_INTERMIDIATES"
+				? "NONE"
+				: this.plugin.settings.hideItems;
 		new Setting(containerEl)
-			.setName("Hide Items")
-			.setDesc("Hide items on the landing or nested tags")
+			.setName("Duplicate file visibility")
+			.setDesc("Nested example: #a/b. Separate-tags example: #a + #b.")
 			.addDropdown((dd) => {
-				dd.addOptions(HideItemsType)
-					.setValue(this.plugin.settings.hideItems)
+				dd.addOptions(visibleHideItemsType)
+					.setValue(visibleHideItemsValue)
 					.onChange(async (key) => {
-						if (
-							key == "NONE" ||
-							key == "DEDICATED_INTERMIDIATES" ||
-							key == "ALL_EXCEPT_BOTTOM"
-						) {
-							this.plugin.settings.hideItems = key;
+						if (key in visibleHideItemsType) {
+							this.plugin.settings.hideItems = key as HIDE_ITEMS_TYPE;
 						}
 						await this.plugin.saveSettings();
 					});
 			});
 		new Setting(containerEl)
-			.setName("Disable narrowing down")
-			.setDesc("Disable narrowing down tags")
+			.setName("Nest separate tags")
+			.setDesc(
+				"Allow separate tags on the same note to form nested paths. Example: #a + #b can appear as #a -> #b."
+			)
 			.addToggle((toggle) => {
 				toggle
 					.setValue(!this.plugin.settings.disableNarrowingDown)
@@ -1595,8 +1606,8 @@ class TagFolderSettingTab extends PluginSettingTab {
 					});
 			});
 		new Setting(containerEl)
-			.setName("Do not treat nested tags as dedicated levels")
-			.setDesc("Treat nested tags as normal tags")
+			.setName("Split nested tags")
+			.setDesc("Treat #a/b as #a and #b instead of as a dedicated #a -> #a/b path.")
 			.addToggle((toggle) => {
 				toggle
 					.setValue(this.plugin.settings.disableNestedTags)
@@ -1606,7 +1617,8 @@ class TagFolderSettingTab extends PluginSettingTab {
 					});
 			});
 		new Setting(containerEl)
-			.setName("Keep untagged items on the root")
+			.setName("Group untagged/unlinked notes")
+			.setDesc("Show untagged notes inside the special untagged folder, and unlinked notes inside the special unlinked folder, instead of as direct root-level file rows.")
 			.addToggle((toggle) => {
 				toggle
 					.setValue(!this.plugin.settings.expandUntaggedToRoot)
@@ -1618,8 +1630,8 @@ class TagFolderSettingTab extends PluginSettingTab {
 
 		containerEl.createEl("h2", { text: "File display" });
 		new Setting(containerEl)
-			.setName("Display Method")
-			.setDesc("You can configure how the entry shows.")
+			.setName("Label")
+			.setDesc("Choose whether file rows show the name, path, or both.")
 			.addDropdown((dropdown) =>
 				dropdown
 					.addOptions({
@@ -1644,8 +1656,8 @@ class TagFolderSettingTab extends PluginSettingTab {
 			// this.plugin.setRoot(this.plugin.root);
 		};
 		new Setting(containerEl)
-			.setName("Order method")
-			.setDesc("how to order items")
+			.setName("Sort order")
+			.setDesc("Choose the field and direction used to sort files inside each folder.")
 			.addDropdown((dd) => {
 				dd.addOptions(OrderKeyItem)
 					.setValue(this.plugin.settings.sortType.split("_")[0])
@@ -1657,8 +1669,8 @@ class TagFolderSettingTab extends PluginSettingTab {
 					.onChange((order) => setOrderMethod(undefined, order));
 			});
 		new Setting(containerEl)
-			.setName("Sort exact items first")
-			.setDesc("Sort items that belong exactly to the folder before items that are shown in sub-folders.")
+			.setName("Sort exact folder matches first")
+			.setDesc("Within each folder, sort files that belong directly to that folder before files that also appear in sub-folders.")
 			.addToggle((toggle) => {
 				toggle
 					.setValue(this.plugin.settings.sortExactFirst)
@@ -1668,9 +1680,9 @@ class TagFolderSettingTab extends PluginSettingTab {
 					});
 			});
 		new Setting(containerEl)
-			.setName("Use title")
+			.setName("Prefer Properties title")
 			.setDesc(
-				"Use value in the frontmatter or first level one heading for `NAME`."
+				"Use the configured Properties value when available; otherwise use the first H1 heading, then the file name."
 			)
 			.addToggle((toggle) => {
 				toggle
@@ -1682,7 +1694,8 @@ class TagFolderSettingTab extends PluginSettingTab {
 					});
 			});
 		const fpath = new Setting(containerEl)
-			.setName("Frontmatter path")
+			.setName("Properties title path")
+			.setDesc("Dotted path to the Properties value used as the file label.")
 			.setDisabled(!this.plugin.settings.useTitle)
 			.addText((text) => {
 				text
@@ -1705,8 +1718,8 @@ class TagFolderSettingTab extends PluginSettingTab {
 			// this.plugin.setRoot(this.plugin.root);
 		};
 		new Setting(containerEl)
-			.setName("Order method")
-			.setDesc("how to order tags")
+			.setName("Sort order")
+			.setDesc("Choose the field and direction used to sort tag folders.")
 			.addDropdown((dd) => {
 				dd.addOptions(OrderKeyTag)
 					.setValue(this.plugin.settings.sortTypeTag.split("_")[0])
@@ -1720,7 +1733,8 @@ class TagFolderSettingTab extends PluginSettingTab {
 
 
 		new Setting(containerEl)
-			.setName("Use virtual tags")
+			.setName("Virtual freshness tags")
+			.setDesc("Group notes by how recently they were edited.")
 			.addToggle((toggle) => {
 				toggle
 					.setValue(this.plugin.settings.useVirtualTag)
@@ -1730,7 +1744,8 @@ class TagFolderSettingTab extends PluginSettingTab {
 					});
 			});
 		new Setting(containerEl)
-			.setName("Display folder as tag")
+			.setName("Vault folders as tags")
+			.setDesc("Add virtual tags based on each note's vault folder path.")
 			.addToggle((toggle) => {
 				toggle
 					.setValue(this.plugin.settings.displayFolderAsTag)
@@ -1742,9 +1757,9 @@ class TagFolderSettingTab extends PluginSettingTab {
 
 		containerEl.createEl("h2", { text: "Pinned tags and aliases" });
 		new Setting(containerEl)
-			.setName("Use pinning")
+			.setName("Enable tag metadata")
 			.setDesc(
-				"Pin tags using metadata from the pin information file."
+				"Read tag metadata from the pin information file. Tags with a `key` value are pinned and sorted before other tags."
 			)
 			.addToggle((toggle) => {
 				toggle
@@ -1759,7 +1774,8 @@ class TagFolderSettingTab extends PluginSettingTab {
 					});
 			});
 		const pi = new Setting(containerEl)
-			.setName("Pin information file")
+			.setName("Metadata file")
+			.setDesc("Markdown file that stores tag metadata such as pin order, custom marks, aliases, and redirects.")
 			.setDisabled(!this.plugin.settings.useTagInfo)
 			.addText((text) => {
 				text
@@ -1775,8 +1791,8 @@ class TagFolderSettingTab extends PluginSettingTab {
 
 		containerEl.createEl("h2", { text: "New notes and templates" });
 		new Setting(containerEl)
-			.setName("Store tags in frontmatter for new notes")
-			.setDesc("When enabled, tags are written to the note Properties. If no new-note template is selected, TagFolder still creates the note and stores tags here instead of as #hashtags.")
+			.setName("Store tags in Properties")
+			.setDesc("When no template is used, write the selected tags to note Properties instead of inserting hashtags in the note body.")
 			.addToggle((toggle) => {
 				toggle
 					.setValue(this.plugin.settings.useFrontmatterTagsForNewNotes)
@@ -1786,8 +1802,8 @@ class TagFolderSettingTab extends PluginSettingTab {
 					});
 			});
 		new Setting(containerEl)
-			.setName("Template for new notes")
-			.setDesc("When set to a valid markdown file path, new notes use this template without opening the template picker. The .md extension is optional.")
+			.setName("Template")
+			.setDesc("Configured markdown template for new notes. Leave empty to use TagFolder's default note creation; an invalid path opens the template picker.")
 			.addText((text) => {
 				text
 					.setPlaceholder("Templates/New note")
@@ -1804,8 +1820,8 @@ class TagFolderSettingTab extends PluginSettingTab {
 
 		containerEl.createEl("h2", { text: "Filters" });
 		new Setting(containerEl)
-			.setName("Target Folders")
-			.setDesc("If configured, the plugin will only target files in it.")
+			.setName("Vault folders - only include")
+			.setDesc("Only index notes whose real vault path starts with one of these comma-separated folders. This does not filter generated tag folders.")
 			.addTextArea((text) =>
 				text
 					.setValue(this.plugin.settings.targetFolders)
@@ -1816,8 +1832,8 @@ class TagFolderSettingTab extends PluginSettingTab {
 					})
 			);
 		new Setting(containerEl)
-			.setName("Ignore Folders")
-			.setDesc("Ignore documents in specific folders.")
+			.setName("Vault folders - exclude")
+			.setDesc("Skip notes whose real vault path starts with one of these comma-separated folders. This does not hide generated tag folders.")
 			.addTextArea((text) =>
 				text
 					.setValue(this.plugin.settings.ignoreFolders)
@@ -1828,9 +1844,9 @@ class TagFolderSettingTab extends PluginSettingTab {
 					})
 			);
 		new Setting(containerEl)
-			.setName("Ignore note Tag")
+			.setName("Tag folders - exclude notes")
 			.setDesc(
-				"If the note has the tag listed below, the note would be treated as there was not."
+				"Remove the whole note from TagFolder if it has any of these comma-separated tags."
 			)
 			.addTextArea((text) =>
 				text
@@ -1842,8 +1858,8 @@ class TagFolderSettingTab extends PluginSettingTab {
 					})
 			);
 		new Setting(containerEl)
-			.setName("Ignore Tag")
-			.setDesc("Tags in the list would be treated as there were not.")
+			.setName("Tag folders - hide tags")
+			.setDesc("Remove these comma-separated tags from the generated tree, but keep each note under its remaining tags.")
 			.addTextArea((text) =>
 				text
 					.setValue(this.plugin.settings.ignoreTags)
@@ -1854,8 +1870,8 @@ class TagFolderSettingTab extends PluginSettingTab {
 					})
 			);
 		new Setting(containerEl)
-			.setName("Archive tags")
-			.setDesc("If configured, notes with these tags will be moved under the tag.")
+			.setName("Tag folders - archive tags")
+			.setDesc("Show notes with these comma-separated tags under the matching generated tag folder instead of their other top-level tag folders.")
 			.addTextArea((text) =>
 				text
 					.setValue(this.plugin.settings.archiveTags)
@@ -1868,7 +1884,8 @@ class TagFolderSettingTab extends PluginSettingTab {
 
 		containerEl.createEl("h2", { text: "Actions and panes" });
 		new Setting(containerEl)
-			.setName("Search tags inside TagFolder when clicking tags")
+			.setName("Tag clicks")
+			.setDesc("Clicking a tag in a note filters TagFolder instead of opening Obsidian's search pane.")
 			.addToggle((toggle) => {
 				toggle
 					.setValue(this.plugin.settings.overrideTagClicking)
@@ -1878,7 +1895,8 @@ class TagFolderSettingTab extends PluginSettingTab {
 					});
 			});
 		new Setting(containerEl)
-			.setName("List files in a separated pane")
+			.setName("Separate file-list pane")
+			.setDesc("Hide file rows from the main tag tree and open folder contents in a separate file-list pane.")
 			.addToggle((toggle) => {
 				toggle
 					.setValue(this.plugin.settings.useMultiPaneList)
@@ -1888,8 +1906,8 @@ class TagFolderSettingTab extends PluginSettingTab {
 					});
 			});
 		new Setting(containerEl)
-			.setName("Show list in")
-			.setDesc("This option applies to the newly opened list")
+			.setName("Open file list in")
+			.setDesc("Default location for newly opened file-list panes when separate file-list panes are enabled.")
 			.addDropdown((dropdown) => {
 				dropdown
 					.addOptions(enumShowListIn)
@@ -1912,8 +1930,8 @@ class TagFolderSettingTab extends PluginSettingTab {
 					})
 			);
 		new Setting(containerEl)
-			.setName("Use Incoming")
-			.setDesc("")
+			.setName("Use incoming")
+			.setDesc("Include backlinks: notes that link to the current note.")
 			.addToggle((toggle) =>
 				toggle
 					.setValue(this.plugin.settings.linkConfig.incoming.enabled)
@@ -1923,8 +1941,8 @@ class TagFolderSettingTab extends PluginSettingTab {
 					})
 			);
 		new Setting(containerEl)
-			.setName("Use Outgoing")
-			.setDesc("")
+			.setName("Use outgoing")
+			.setDesc("Include outgoing links: notes that the current note links to.")
 			.addToggle((toggle) =>
 				toggle
 					.setValue(this.plugin.settings.linkConfig.outgoing.enabled)
@@ -1934,8 +1952,8 @@ class TagFolderSettingTab extends PluginSettingTab {
 					})
 			);
 		new Setting(containerEl)
-			.setName("Hide indirectly linked notes")
-			.setDesc("")
+			.setName("Hide indirect notes")
+			.setDesc("Show only first-degree linked notes. Hide notes that are reached only through another linked note.")
 			.addToggle((toggle) =>
 				toggle
 					.setValue(this.plugin.settings.linkShowOnlyFDR)
@@ -1945,8 +1963,8 @@ class TagFolderSettingTab extends PluginSettingTab {
 					})
 			);
 		new Setting(containerEl)
-			.setName("Connect linked tree")
-			.setDesc("")
+			.setName("Combine related branches")
+			.setDesc("Currently unused. Changing this setting does not alter Link Folder behavior.")
 			.addToggle((toggle) =>
 				toggle
 					.setValue(this.plugin.settings.linkCombineOtherTree)
@@ -1961,7 +1979,7 @@ class TagFolderSettingTab extends PluginSettingTab {
 		new Setting(containerEl)
 			.setName("Tag scanning delay")
 			.setDesc(
-				"Sets the delay for reflecting metadata changes to the tag tree. (Plugin reload is required.)"
+				"Debounce delay in milliseconds for vault refresh events such as rename, delete, and modify. Plugin reload is required."
 			)
 			.addText((text) => {
 				text = text
@@ -1979,8 +1997,8 @@ class TagFolderSettingTab extends PluginSettingTab {
 				return text;
 			});
 		new Setting(containerEl)
-			.setName("Disable dragging tags")
-			.setDesc("The `Dragging tags` is using internal APIs. If something happens, please disable this once and try again.")
+			.setName("Disable tag dragging")
+			.setDesc("Turn this on if drag-and-drop tag movement causes problems. This feature uses Obsidian internal APIs.")
 			.addToggle((toggle) => {
 				toggle
 					.setValue(this.plugin.settings.disableDragging)
@@ -1992,9 +2010,9 @@ class TagFolderSettingTab extends PluginSettingTab {
 		containerEl.createEl("h2", { text: "Utilities" });
 
 		new Setting(containerEl)
-			.setName("Dumping tags for reporting bugs")
+			.setName("Copy tags for bug reports")
 			.setDesc(
-				"If you want to open an issue to the GitHub, this information can be useful. and, also if you want to keep secrets about names of tags, you can use `disguised`."
+				"Copy the current tag data for a GitHub issue. Use disguised tags if the real tag names are private."
 			)
 			.addButton((button) =>
 				button

--- a/types.ts
+++ b/types.ts
@@ -180,18 +180,18 @@ export type TREE_TYPE = "tags" | "links";
 
 export const OrderKeyTag: Record<string, string> = {
 	NAME: "Tag name",
-	ITEMS: "Count of items",
+	ITEMS: "Number of files",
 };
 export const OrderDirection: Record<string, string> = {
 	ASC: "Ascending",
 	DESC: "Descending",
 };
 export const OrderKeyItem: Record<string, string> = {
-	DISPNAME: "Displaying name",
+	DISPNAME: "File label",
 	NAME: "File name",
 	MTIME: "Modified time",
 	CTIME: "Created time",
-	FULLPATH: "Fullpath of the file",
+	FULLPATH: "Full file path",
 };
 
 


### PR DESCRIPTION
Complete overhaul of the plugins' settings menu.

Reorganization of settings, renaming of settings and added descriptions for clarification.

Many issues on this repo are from people requesting features that are already available but they couldn't find them. Such as [showing notes only in subfolderes](https://github.com/vrtmrz/obsidian-tagfolder/issues/135) etc.

That's why I wanted to reorganize the settings and also added a quick setup on top.

What do you think about these changes? I split them up into 2 commits. The first one is about the restructuring of the  settings and the second one about my personal adjustments to clarify many settings.