### PR TITLE
make "tag click" also show the clicked tag

### DIFF
--- a/TagFolderViewComponent.svelte
+++ b/TagFolderViewComponent.svelte
@@ -115,6 +115,11 @@
 		onlyFDREnabled = _setting.linkShowOnlyFDR;
 	});
 	let showSearch = $state(false);
+	$effect(() => {
+		if ($searchString.trim() !== "") {
+			showSearch = true;
+		}
+	});
 	function toggleSearch() {
 		showSearch = !showSearch;
 		if (!showSearch) {


### PR DESCRIPTION
When "tag click" is enabled (clicking a tag in a note filters TagFolder View instead of opening Obsidian's native Tag search pane), it also shows the filter that was applied:
<img width="480" height="174" alt="90806" src="https://github.com/user-attachments/assets/33a9ce08-0497-4750-941c-aa37cba5cf70" />

this way it can be deselected with one mouse click instead of 2 (first clicking the search icon, then the "x"), as it was before.