### PR TITLE
Adopt Fancy Kit UI and Vault harnesses

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,3 +292,7 @@ If the note has the tag that is set in here, the note would be treated as there 
 Tags that were set here would be treated as there were not.
 
 ##### Archive tags
+
+## Development
+
+Contributor setup, tests, and UI/Vault workflow architecture are documented in [the developer guide](docs/devs.md).

--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ This setting changes how tags are stored in new notes created by TagFolder. When
 
 When this setting is set to a valid markdown template path, TagFolder uses that template immediately when creating a new note from the tag tree. The `.md` extension is optional. If a non-empty path is invalid, TagFolder opens a template picker. If the setting is empty, TagFolder creates the note without a template and uses the configured Properties or hashtag behaviour.
 
+Settings suggestions are captured when the settings tab opens; reopen the tab to refresh them. The new-note template selection dialog captures a fresh list each time it opens.
+
 Templates can include these placeholders, which are replaced with the tags from the clicked location:
 
 | Placeholder        | Replacement                         |

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ This setting changes how tags are stored in new notes created by TagFolder. When
 
 ##### Template for new notes
 
-When this setting is set to a valid markdown template path, TagFolder uses that template immediately when creating a new note from the tag tree. The `.md` extension is optional. If the setting is empty or invalid, TagFolder opens a template picker.
+When this setting is set to a valid markdown template path, TagFolder uses that template immediately when creating a new note from the tag tree. The `.md` extension is optional. If a non-empty path is invalid, TagFolder opens a template picker. If the setting is empty, TagFolder creates the note without a template and uses the configured Properties or hashtag behaviour.
 
 Templates can include these placeholders, which are replaced with the tags from the clicked location:
 

--- a/docs/devs.md
+++ b/docs/devs.md
@@ -1,0 +1,55 @@
+# Developer guide
+
+## Setup and checks
+
+Install the locked dependencies and run the repository gate:
+
+```bash
+npm ci
+npm run check
+npm run build
+```
+
+The App-free Vitest suite includes TagFolder tree utilities and the new-note application workflow.
+
+## UI and Vault boundaries
+
+The plug-in owns one `UiInteractions` capability and one `VaultTextAccess` capability for its lifetime:
+
+```ts
+this.ui = createObsidianUi(this.app);
+this.vaultText = createObsidianVaultTextAccess(this.app.vault);
+```
+
+`new-note-workflow.ts` accepts those capabilities instead of constructing an Obsidian template modal or reading and writing `TFile` instances directly. TagFolder still owns template variables, frontmatter policy, note creation, settings, and visible labels.
+
+Application-flow tests use instance-scoped App-free harnesses:
+
+```ts
+const ui = createUiTestHarness([
+	{ kind: "pickOne", interactionId: "new-note-template", value: template },
+]);
+const vault = createVaultTextTestHarness({
+	files: {
+		"Templates/project.md": "# {{tagName}}",
+		"Untitled.md": "",
+	},
+});
+```
+
+The UI transcript verifies the stable interaction ID and selected object identity. The Vault transcript verifies template reads, note writes, write ordering, and the absence of text writes when frontmatter owns the update.
+
+The path-based Vault capability deliberately does not replace real Obsidian coverage for `TFile` identity, Vault events, MetadataCache propagation, or frontmatter processing.
+
+## Fancy Kit preview
+
+Until Fancy Kit is published to npm, its packages are pinned to immutable tarballs from one GitHub prerelease. Update the UI interactions, Obsidian plug-in kit, and test-session URLs together when a migration needs a newer preview.
+
+Real-Obsidian scenarios are local-only and currently validated on Linux only.
+
+```bash
+npm run check:e2e:obsidian
+npm run test:e2e:obsidian:new-note-template
+```
+
+The real scenario uses the production UI and Vault adapters. It selects a template through Obsidian, creates a real note, and verifies the persisted content; it never installs a scripted driver into the plug-in.

--- a/main.ts
+++ b/main.ts
@@ -14,12 +14,16 @@ import {
 	Plugin,
 	PluginSettingTab,
 	Setting,
-	SuggestModal,
 	TFile,
 	WorkspaceLeaf,
 	TAbstractFile,
 	type MarkdownFileInfo,
 } from "obsidian";
+import { createObsidianUi, type UiInteractions } from "@vrtmrz/obsidian-plugin-kit/ui";
+import {
+	createObsidianVaultTextAccess,
+	type VaultTextAccess,
+} from "@vrtmrz/obsidian-plugin-kit/vault";
 
 import {
 	DEFAULT_SETTINGS,
@@ -56,7 +60,11 @@ import {
 	trimPrefix,
 	uniqueCaseIntensive
 } from "./util";
-import { renderTagFolderTemplateVariables } from "./new-note-template";
+import {
+	chooseNewNoteTemplate,
+	populateNewNote,
+	type NewNoteTemplateChoice,
+} from "./new-note-workflow";
 import { ScrollView } from "./ScrollView";
 import { TagFolderView } from "./TagFolderView";
 import { TagFolderList } from "./TagFolderList";
@@ -100,8 +108,6 @@ function getCompareMethodItems(settings: TagFolderSettings) {
 	}
 }
 
-type NewNoteTemplateChoice = TFile;
-
 function getCoreTemplatesFolder(app: App): string | null {
 	const internalPlugins = (app as App & {
 		internalPlugins?: {
@@ -135,44 +141,6 @@ function getTemplateFiles(app: App) {
 	return templates.sort((a, b) => compare(a.path, b.path));
 }
 
-class NewNoteTemplateSuggestModal extends SuggestModal<NewNoteTemplateChoice> {
-	private callback?: (template: NewNoteTemplateChoice | false) => void;
-	private templates: TFile[];
-
-	constructor(app: App, templates: TFile[], callback: (template: NewNoteTemplateChoice | false) => void) {
-		super(app);
-		this.templates = templates;
-		this.callback = callback;
-		this.setPlaceholder("Type to search templates...");
-	}
-
-	getSuggestions(query: string): NewNoteTemplateChoice[] {
-		const normalizedQuery = query.toLowerCase();
-		return this.templates.filter((file) =>
-			file.path.toLowerCase().contains(normalizedQuery)
-		);
-	}
-
-	renderSuggestion(template: NewNoteTemplateChoice, el: HTMLElement) {
-		el.createDiv({ text: template.basename });
-		el.createDiv({ text: template.path, cls: "suggestion-note" });
-	}
-
-	onChooseSuggestion(template: NewNoteTemplateChoice) {
-		this.callback?.(template);
-		this.callback = undefined;
-	}
-
-	onClose(): void {
-		window.setTimeout(() => {
-			if (this.callback) {
-				this.callback(false);
-				this.callback = undefined;
-			}
-		}, 100);
-	}
-}
-
 class NewNoteTemplateInputSuggest extends AbstractInputSuggest<TFile> {
 	private callback: (template: TFile) => void;
 
@@ -201,20 +169,19 @@ class NewNoteTemplateInputSuggest extends AbstractInputSuggest<TFile> {
 	}
 }
 
-function askNewNoteTemplate(app: App): Promise<NewNoteTemplateChoice | false> {
-	return new Promise((resolve) => {
-		const templates = getTemplateFiles(app);
-		if (templates.length == 0) {
-			new Notice("No templates found");
-			resolve(false);
-			return;
-		}
-		const modal = new NewNoteTemplateSuggestModal(app, templates, resolve);
-		modal.open();
-	});
+async function askNewNoteTemplate(ui: UiInteractions, app: App): Promise<NewNoteTemplateChoice | null> {
+	const templates = getTemplateFiles(app).map((file) => ({
+		path: file.path,
+		name: file.basename,
+	}));
+	if (templates.length == 0) {
+		new Notice("No templates found");
+		return null;
+	}
+	return await chooseNewNoteTemplate(ui, templates);
 }
 
-function getConfiguredNewNoteTemplate(app: App, templatePath: string): TFile | null {
+function getConfiguredNewNoteTemplate(app: App, templatePath: string): NewNoteTemplateChoice | null {
 	const inputPath = normalizeNewNoteTemplatePath(templatePath);
 	if (inputPath == "") return null;
 
@@ -240,7 +207,7 @@ function getConfiguredNewNoteTemplate(app: App, templatePath: string): TFile | n
 		return null;
 	}
 
-	return file;
+	return { path: file.path, name: file.basename };
 }
 
 function normalizeNewNoteTemplatePath(templatePath: string) {
@@ -260,6 +227,8 @@ function onElement<T extends HTMLElement | Document>(el: T, event: string, selec
 
 export default class TagFolderPlugin extends Plugin {
 	settings: TagFolderSettings = { ...DEFAULT_SETTINGS };
+	ui!: UiInteractions;
+	vaultText!: VaultTextAccess;
 
 	// Folder opening status.
 	expandedFolders: string[] = ["root"];
@@ -367,6 +336,8 @@ export default class TagFolderPlugin extends Plugin {
 
 	async onload() {
 		await this.loadSettings();
+		this.ui = createObsidianUi(this.app);
+		this.vaultText = createObsidianVaultTextAccess(this.app.vault);
 		this.hoverPreview = this.hoverPreview.bind(this);
 		this.modifyFile = this.modifyFile.bind(this);
 		this.setSearchString = this.setSearchString.bind(this);
@@ -1402,31 +1373,28 @@ export default class TagFolderPlugin extends Plugin {
 		const selectedTemplate = configuredTemplatePath == ""
 			? null
 			: (getConfiguredNewNoteTemplate(this.app, configuredTemplatePath)
-				?? await askNewNoteTemplate(this.app));
+				?? await askNewNoteTemplate(this.ui, this.app));
 
 		//@ts-ignore
 		const ww = await this.app.fileManager.createAndOpenMarkdownFile();
 		if (!(ww instanceof TFile)) return;
-		if (selectedTemplate != null && selectedTemplate !== false) {
-			const template = await this.app.vault.read(selectedTemplate);
-			const renderedTemplate = renderTagFolderTemplateVariables(template, expandedTagsAll, expandedTags);
-			if (renderedTemplate.trim() != "") {
-				await this.app.vault.modify(ww, renderedTemplate);
-			}
-			return;
-		}
-
-		if (this.settings.useFrontmatterTagsForNewNotes) {
-			await this.app.fileManager.processFrontMatter(ww, (matter) => {
-				matter.tags = matter.tags ?? [];
-				matter.tags = expandedTagsAll
-					.filter(e => !isSpecialTag(e))
-					.filter(e => matter.tags.indexOf(e) < 0)
-					.concat(matter.tags);
-			});
-		} else {
-			await this.app.vault.append(ww, expandedTags);
-		}
+		await populateNewNote({
+			vault: this.vaultText,
+			notePath: ww.path,
+			template: selectedTemplate,
+			expandedTagsAll,
+			expandedTags,
+			frontmatterTags: expandedTagsAll.filter(e => !isSpecialTag(e)),
+			useFrontmatterTags: this.settings.useFrontmatterTagsForNewNotes,
+			applyFrontmatterTags: async (frontmatterTags) => {
+				await this.app.fileManager.processFrontMatter(ww, (matter) => {
+					matter.tags = matter.tags ?? [];
+					matter.tags = frontmatterTags
+						.filter(e => matter.tags.indexOf(e) < 0)
+						.concat(matter.tags);
+				});
+			},
+		});
 	}
 }
 

--- a/main.ts
+++ b/main.ts
@@ -62,6 +62,7 @@ import {
 } from "./util";
 import {
 	chooseNewNoteTemplate,
+	filterNewNoteTemplateChoices,
 	populateNewNote,
 	type NewNoteTemplateChoice,
 } from "./new-note-workflow";
@@ -141,44 +142,51 @@ function getTemplateFiles(app: App) {
 	return templates.sort((a, b) => compare(a.path, b.path));
 }
 
-class NewNoteTemplateInputSuggest extends AbstractInputSuggest<TFile> {
-	private callback: (template: TFile) => void;
+function captureNewNoteTemplates(app: App): NewNoteTemplateChoice[] {
+	return getTemplateFiles(app).map((file) => ({
+		path: file.path,
+		name: file.basename,
+	}));
+}
 
-	constructor(app: App, inputEl: HTMLInputElement, callback: (template: TFile) => void) {
+class NewNoteTemplateInputSuggest extends AbstractInputSuggest<NewNoteTemplateChoice> {
+	private readonly templates: readonly NewNoteTemplateChoice[];
+	private callback: (template: NewNoteTemplateChoice) => void;
+
+	constructor(
+		app: App,
+		inputEl: HTMLInputElement,
+		templates: readonly NewNoteTemplateChoice[],
+		callback: (template: NewNoteTemplateChoice) => void,
+	) {
 		super(app, inputEl);
+		this.templates = templates;
 		this.callback = callback;
 	}
 
-	getSuggestions(query: string): TFile[] {
-		const normalizedQuery = query.toLowerCase();
-		return getTemplateFiles(this.app).filter((file) =>
-			file.path.toLowerCase().contains(normalizedQuery)
-			|| file.basename.toLowerCase().contains(normalizedQuery)
-		);
+	getSuggestions(query: string): NewNoteTemplateChoice[] {
+		return filterNewNoteTemplateChoices(this.templates, query);
 	}
 
-	renderSuggestion(template: TFile, el: HTMLElement) {
-		el.createDiv({ text: template.basename });
+	renderSuggestion(template: NewNoteTemplateChoice, el: HTMLElement) {
+		el.createDiv({ text: template.name });
 		el.createDiv({ text: template.path, cls: "suggestion-note" });
 	}
 
-	selectSuggestion(template: TFile) {
+	selectSuggestion(template: NewNoteTemplateChoice) {
 		this.setValue(template.path);
 		this.callback(template);
 		this.close();
 	}
 }
 
-async function askNewNoteTemplate(ui: UiInteractions, app: App): Promise<NewNoteTemplateChoice | null> {
-	const templates = getTemplateFiles(app).map((file) => ({
-		path: file.path,
-		name: file.basename,
-	}));
-	if (templates.length == 0) {
-		new Notice("No templates found");
-		return null;
+async function askNewNoteTemplate(ui: UiInteractions, app: App): Promise<NewNoteTemplateChoice | null | undefined> {
+	const templates = captureNewNoteTemplates(app);
+	const selectedTemplate = await chooseNewNoteTemplate(ui, templates);
+	if (selectedTemplate === undefined) {
+		new Notice("No templates found. Add a template, then try again.");
 	}
-	return await chooseNewNoteTemplate(ui, templates);
+	return selectedTemplate;
 }
 
 function getConfiguredNewNoteTemplate(app: App, templatePath: string): NewNoteTemplateChoice | null {
@@ -1370,10 +1378,17 @@ export default class TagFolderPlugin extends Plugin {
 			.trim();
 
 		const configuredTemplatePath = normalizeNewNoteTemplatePath(this.settings.newNoteTemplate);
-		const selectedTemplate = configuredTemplatePath == ""
-			? null
-			: (getConfiguredNewNoteTemplate(this.app, configuredTemplatePath)
-				?? await askNewNoteTemplate(this.ui, this.app));
+		let selectedTemplate: NewNoteTemplateChoice | null = null;
+		if (configuredTemplatePath != "") {
+			const configuredTemplate = getConfiguredNewNoteTemplate(this.app, configuredTemplatePath);
+			if (configuredTemplate != null) {
+				selectedTemplate = configuredTemplate;
+			} else {
+				const promptedTemplate = await askNewNoteTemplate(this.ui, this.app);
+				if (promptedTemplate === undefined) return;
+				selectedTemplate = promptedTemplate;
+			}
+		}
 
 		//@ts-ignore
 		const ww = await this.app.fileManager.createAndOpenMarkdownFile();
@@ -1413,6 +1428,7 @@ class TagFolderSettingTab extends PluginSettingTab {
 	display(): void {
 		const { containerEl } = this;
 		containerEl.empty();
+		const newNoteTemplates = captureNewNoteTemplates(this.app);
 
 		new Setting(containerEl).setName("Behavior").setHeading();
 		new Setting(containerEl)
@@ -1615,7 +1631,7 @@ class TagFolderSettingTab extends PluginSettingTab {
 						this.plugin.settings.newNoteTemplate = normalizeNewNoteTemplatePath(value);
 						await this.plugin.saveSettings();
 					});
-				new NewNoteTemplateInputSuggest(this.app, text.inputEl, (template) => {
+				new NewNoteTemplateInputSuggest(this.app, text.inputEl, newNoteTemplates, (template) => {
 					this.plugin.settings.newNoteTemplate = template.path;
 					void this.plugin.saveSettings();
 				});

--- a/new-note-workflow.ts
+++ b/new-note-workflow.ts
@@ -1,0 +1,73 @@
+import type { UiInteractions } from "@vrtmrz/obsidian-plugin-kit/ui";
+import type { VaultTextAccess } from "@vrtmrz/obsidian-plugin-kit/vault";
+import { renderTagFolderTemplateVariables } from "./new-note-template";
+
+export const NEW_NOTE_TEMPLATE_INTERACTION_ID = "new-note-template";
+
+/** Template identity and labels exposed to the application workflow. */
+export interface NewNoteTemplateChoice {
+	/** Vault-relative template path. */
+	readonly path: string;
+	/** Primary visible template name. */
+	readonly name: string;
+}
+
+/** Requests one template by identity, or returns `null` when dismissed or empty. */
+export async function chooseNewNoteTemplate(
+	ui: UiInteractions,
+	templates: readonly NewNoteTemplateChoice[],
+): Promise<NewNoteTemplateChoice | null> {
+	if (templates.length == 0) return null;
+	return await ui.pickOne(
+		{
+			items: templates,
+			getText: (template) => template.name,
+			getDescription: (template) => template.path,
+			placeholder: "Type to search templates...",
+		},
+		NEW_NOTE_TEMPLATE_INTERACTION_ID,
+	);
+}
+
+/** Inputs owned by TagFolder while populating a newly created note. */
+export interface PopulateNewNoteOptions {
+	/** Injectable path-based Vault text capability. */
+	readonly vault: VaultTextAccess;
+	/** Vault-relative path of the already created note. */
+	readonly notePath: string;
+	/** Selected template, or `null` to apply tags without a template. */
+	readonly template: NewNoteTemplateChoice | null;
+	/** Expanded tags used by template variables. */
+	readonly expandedTagsAll: readonly string[];
+	/** Expanded hashtag string used by template variables or body append. */
+	readonly expandedTags: string;
+	/** Non-special tags supplied to the frontmatter callback. */
+	readonly frontmatterTags: readonly string[];
+	/** Whether no-template tags should be written through frontmatter. */
+	readonly useFrontmatterTags: boolean;
+	/** Consumer-owned Obsidian frontmatter mutation. */
+	readonly applyFrontmatterTags: (tags: readonly string[]) => Promise<void>;
+}
+
+/** Populates a new note from a template, frontmatter tags, or appended hashtags. */
+export async function populateNewNote(options: PopulateNewNoteOptions): Promise<void> {
+	if (options.template !== null) {
+		const template = await options.vault.readText(options.template.path);
+		const renderedTemplate = renderTagFolderTemplateVariables(
+			template,
+			[...options.expandedTagsAll],
+			options.expandedTags,
+		);
+		if (renderedTemplate.trim() != "") {
+			await options.vault.modifyText(options.notePath, renderedTemplate);
+		}
+		return;
+	}
+
+	if (options.useFrontmatterTags) {
+		await options.applyFrontmatterTags(options.frontmatterTags);
+		return;
+	}
+
+	await options.vault.appendText(options.notePath, options.expandedTags);
+}

--- a/new-note-workflow.ts
+++ b/new-note-workflow.ts
@@ -12,12 +12,24 @@ export interface NewNoteTemplateChoice {
 	readonly name: string;
 }
 
-/** Requests one template by identity, or returns `null` when dismissed or empty. */
+/** Filters one captured template snapshot by name or Vault-relative path. */
+export function filterNewNoteTemplateChoices(
+	templates: readonly NewNoteTemplateChoice[],
+	query: string,
+): NewNoteTemplateChoice[] {
+	const normalizedQuery = query.toLowerCase();
+	return templates.filter((template) =>
+		template.path.toLowerCase().includes(normalizedQuery)
+		|| template.name.toLowerCase().includes(normalizedQuery)
+	);
+}
+
+/** Requests one captured template by identity, returns `null` when dismissed, or `undefined` when empty. */
 export async function chooseNewNoteTemplate(
 	ui: UiInteractions,
 	templates: readonly NewNoteTemplateChoice[],
-): Promise<NewNoteTemplateChoice | null> {
-	if (templates.length == 0) return null;
+): Promise<NewNoteTemplateChoice | null | undefined> {
+	if (templates.length == 0) return undefined;
 	return await ui.pickOne(
 		{
 			items: templates,

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,8 @@
 				"@vrtmrz/ui-interactions": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.3/vrtmrz-ui-interactions-0.0.0.tgz"
 			},
 			"devDependencies": {
+				"@emnapi/core": "1.11.2",
+				"@emnapi/runtime": "1.11.2",
 				"@eslint/js": "^9.39.1",
 				"@tsconfig/svelte": "^5.0.4",
 				"@types/node": "^22.20.1",
@@ -327,13 +329,35 @@
 				"node": ">=20.19.0"
 			}
 		},
+		"node_modules/@emnapi/core": {
+			"version": "1.11.2",
+			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
+			"integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@emnapi/wasi-threads": "1.2.2",
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@emnapi/runtime": {
+			"version": "1.11.2",
+			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+			"integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
 		"node_modules/@emnapi/wasi-threads": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
 			"integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
 			"dev": true,
 			"license": "MIT",
-			"optional": true,
 			"dependencies": {
 				"tslib": "^2.4.0"
 			}
@@ -7702,12 +7726,32 @@
 			"dev": true,
 			"peer": true
 		},
+		"@emnapi/core": {
+			"version": "1.11.2",
+			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
+			"integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
+			"dev": true,
+			"peer": true,
+			"requires": {
+				"@emnapi/wasi-threads": "1.2.2",
+				"tslib": "^2.4.0"
+			}
+		},
+		"@emnapi/runtime": {
+			"version": "1.11.2",
+			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+			"integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+			"dev": true,
+			"peer": true,
+			"requires": {
+				"tslib": "^2.4.0"
+			}
+		},
 		"@emnapi/wasi-threads": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
 			"integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
 			"dev": true,
-			"optional": true,
 			"requires": {
 				"tslib": "^2.4.0"
 			}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,12 +8,17 @@
 			"name": "obsidian-tagfolder",
 			"version": "0.18.16",
 			"license": "MIT",
+			"dependencies": {
+				"@vrtmrz/obsidian-plugin-kit": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.3/vrtmrz-obsidian-plugin-kit-0.0.0.tgz",
+				"@vrtmrz/ui-interactions": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.3/vrtmrz-ui-interactions-0.0.0.tgz"
+			},
 			"devDependencies": {
 				"@eslint/js": "^9.39.1",
 				"@tsconfig/svelte": "^5.0.4",
-				"@types/node": "^22.7.9",
+				"@types/node": "^22.20.1",
 				"@typescript-eslint/parser": "^8.48.1",
 				"@vitest/coverage-v8": "^4.1.9",
+				"@vrtmrz/obsidian-test-session": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.3/vrtmrz-obsidian-test-session-0.0.0.tgz",
 				"esbuild": "^0.28.1",
 				"esbuild-svelte": "^0.9.3",
 				"eslint": "^9.39.1",
@@ -22,11 +27,13 @@
 				"globals": "^14.0.0",
 				"jsdom": "^29.1.1",
 				"obsidian": "^1.10.3",
+				"playwright": "^1.61.1",
 				"svelte": "^5.45.5",
 				"svelte-check": "^4.3.4",
 				"svelte-eslint-parser": "^1.8.0",
 				"svelte-preprocess": "^6.0.3",
 				"terser": "^5.44.1",
+				"tsx": "^4.23.0",
 				"typescript": "^5.9.3",
 				"vitest": "^4.1.9"
 			}
@@ -159,7 +166,6 @@
 			"version": "6.5.0",
 			"resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.5.0.tgz",
 			"integrity": "sha512-MwBHVK60IiIHDcoMet78lxt6iw5gJOGSbNbOIVBHWVXIH4/Nq1+GQgLLGgI1KlnN86WDXsPudVaqYHKBIx7Eyw==",
-			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
@@ -170,7 +176,6 @@
 			"version": "6.38.6",
 			"resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.38.6.tgz",
 			"integrity": "sha512-qiS0z1bKs5WOvHIAC0Cybmv4AJSkAXgX5aD6Mqd2epSLlVJsQl8NG23jCVouIgkh4All/mrbdsf2UOLFnJw0tw==",
-			"dev": true,
 			"license": "MIT",
 			"peer": true,
 			"dependencies": {
@@ -268,6 +273,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=20.19.0"
 			},
@@ -316,31 +322,9 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=20.19.0"
-			}
-		},
-		"node_modules/@emnapi/core": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
-			"integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"@emnapi/wasi-threads": "1.2.2",
-				"tslib": "^2.4.0"
-			}
-		},
-		"node_modules/@emnapi/runtime": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
-			"integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"tslib": "^2.4.0"
 			}
 		},
 		"node_modules/@emnapi/wasi-threads": {
@@ -1099,9 +1083,7 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
 			"integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/@microsoft/eslint-plugin-sdl": {
 			"version": "1.1.0",
@@ -1406,6 +1388,29 @@
 				"node": "^20.19.0 || >=22.12.0"
 			}
 		},
+		"node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/core": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+			"integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"@emnapi/wasi-threads": "1.2.2",
+				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@rolldown/binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+			"integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"dependencies": {
+				"tslib": "^2.4.0"
+			}
+		},
 		"node_modules/@rolldown/binding-win32-arm64-msvc": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.3.tgz",
@@ -1503,7 +1508,6 @@
 			"version": "5.60.8",
 			"resolved": "https://registry.npmjs.org/@types/codemirror/-/codemirror-5.60.8.tgz",
 			"integrity": "sha512-VjFgDF/eB+Aklcy15TtOTLQeMjTo07k7KAjql8OK5Dirr7a6sJY4T1uVBDuTVG9VEmn1uUsohOpYnVfgC6/jyw==",
-			"dev": true,
 			"dependencies": {
 				"@types/tern": "*"
 			}
@@ -1529,8 +1533,7 @@
 		"node_modules/@types/estree": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
-			"integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
-			"dev": true
+			"integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw=="
 		},
 		"node_modules/@types/json-schema": {
 			"version": "7.0.15",
@@ -1547,19 +1550,20 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/node": {
-			"version": "22.7.9",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.9.tgz",
-			"integrity": "sha512-jrTfRC7FM6nChvU7X2KqcrgquofrWLFDeYC1hKfwNWomVvrn7JIksqf344WN2X/y8xrgqBd2dJATZV4GbatBfg==",
+			"version": "22.20.1",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+			"integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
 			"dev": true,
+			"license": "MIT",
+			"peer": true,
 			"dependencies": {
-				"undici-types": "~6.19.2"
+				"undici-types": "~6.21.0"
 			}
 		},
 		"node_modules/@types/tern": {
 			"version": "0.23.9",
 			"resolved": "https://registry.npmjs.org/@types/tern/-/tern-0.23.9.tgz",
 			"integrity": "sha512-ypzHFE/wBzh+BlH6rrBgS5I/Z7RD21pGhZ2rltb/+ZrVM1awdZwjx7hE5XfuYgHWk9uvV5HLZN3SloevCAp3Bw==",
-			"dev": true,
 			"dependencies": {
 				"@types/estree": "*"
 			}
@@ -1616,6 +1620,7 @@
 			"integrity": "sha512-PJ5vePq5/ognBbrIcoC5+SHO5dfpeLPzP9FpLkzWrguoYQEeeSjlJpVwOpo1JRSTEi7dRcwNy4h4dzV70PqHcg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/scope-manager": "8.61.1",
 				"@typescript-eslint/types": "8.61.1",
@@ -1859,6 +1864,7 @@
 			"integrity": "sha512-G9/lgqibheLVBDRuya45EbsEXTYcWoSG+TLg7i2axuzx0Eq62eXn+aWXyaVdV5vKvFSWd6ywcX8hA7la9Pvu8g==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@bcoe/v8-coverage": "^1.0.2",
 				"@vitest/utils": "4.1.9",
@@ -1970,12 +1976,44 @@
 				"url": "https://opencollective.com/vitest"
 			}
 		},
+		"node_modules/@vrtmrz/obsidian-plugin-kit": {
+			"version": "0.0.0",
+			"resolved": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.3/vrtmrz-obsidian-plugin-kit-0.0.0.tgz",
+			"integrity": "sha512-nWPtnxO7wImPmANjSHlka1o62X/MQScCVvmegYtG0jW56fNPUvzLF5cd86RJUdUcTZsgXrk6s3d3N2SdXOR5Xw==",
+			"license": "MIT",
+			"dependencies": {
+				"@vrtmrz/ui-interactions": "0.0.0"
+			},
+			"peerDependencies": {
+				"obsidian": ">=1.8.7"
+			}
+		},
+		"node_modules/@vrtmrz/obsidian-test-session": {
+			"version": "0.0.0",
+			"resolved": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.3/vrtmrz-obsidian-test-session-0.0.0.tgz",
+			"integrity": "sha512-XHWFORR8Q7vQsbKxrj8RBgpyC7DHFw5PSUXkBOKJoHnx9abgCkuQp4gYYa64RO7sOdRx/Xj799JOop+McQSqsg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=20"
+			},
+			"peerDependencies": {
+				"playwright": ">=1.50.0"
+			}
+		},
+		"node_modules/@vrtmrz/ui-interactions": {
+			"version": "0.0.0",
+			"resolved": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.3/vrtmrz-ui-interactions-0.0.0.tgz",
+			"integrity": "sha512-pMFOq2FRKpj0Eq0Jdc1H5gZOv5W0liMNVVAVgpHovA5Bmb8alESjFnS25Y7eapUx6pIbFmbnFeqkhLQGUefCqg==",
+			"license": "MIT"
+		},
 		"node_modules/acorn": {
 			"version": "8.15.0",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
 			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -2448,9 +2486,7 @@
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
 			"integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.6",
@@ -2902,6 +2938,7 @@
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"esbuild": "bin/esbuild"
 			},
@@ -2972,6 +3009,7 @@
 			"integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.8.0",
 				"@eslint-community/regexpp": "^4.12.1",
@@ -4660,6 +4698,7 @@
 			"integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@asamuzakjp/css-color": "^5.1.11",
 				"@asamuzakjp/dom-selector": "^7.1.1",
@@ -5252,7 +5291,6 @@
 			"version": "2.29.4",
 			"resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
 			"integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
-			"dev": true,
 			"engines": {
 				"node": "*"
 			}
@@ -5453,8 +5491,8 @@
 			"version": "1.12.3",
 			"resolved": "https://registry.npmjs.org/obsidian/-/obsidian-1.12.3.tgz",
 			"integrity": "sha512-HxWqe763dOqzXjnNiHmAJTRERN8KILBSqxDSEqbeSr7W8R8Jxezzbca+nz1LiiqXnMpM8lV2jzAezw3CZ4xNUw==",
-			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@types/codemirror": "5.60.8",
 				"moment": "2.29.4"
@@ -5613,11 +5651,60 @@
 			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/playwright": {
+			"version": "1.61.1",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+			"integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"playwright-core": "1.61.1"
+			},
+			"bin": {
+				"playwright": "cli.js"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"optionalDependencies": {
+				"fsevents": "2.3.2"
+			}
+		},
+		"node_modules/playwright-core": {
+			"version": "1.61.1",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+			"integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"playwright-core": "cli.js"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/playwright/node_modules/fsevents": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
 			}
 		},
 		"node_modules/possible-typed-array-names": {
@@ -5650,6 +5737,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"nanoid": "^3.3.12",
 				"picocolors": "^1.1.1",
@@ -6413,9 +6501,7 @@
 			"version": "4.1.3",
 			"resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
 			"integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/supports-color": {
 			"version": "7.2.0",
@@ -6448,6 +6534,7 @@
 			"integrity": "sha512-w7JvrM5IFl5cmfbY0TLik9o7mjRUJmRMhOR51tBPu708Gr/MjbGs7VnJnr/B0CaXeI4vtnOh7RKxDr0cwhMdDA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@jridgewell/remapping": "^2.3.4",
 				"@jridgewell/sourcemap-codec": "^1.5.0",
@@ -6637,6 +6724,7 @@
 			"integrity": "sha512-t/R3R/n0MSwnnazuPpPNVO60LX0SKL45pyl9YlvxIdkH0Of7D5qM2EVe+yASRIlY5pZ73nclYJfNANGWPwFDZw==",
 			"dev": true,
 			"license": "BSD-2-Clause",
+			"peer": true,
 			"dependencies": {
 				"@jridgewell/source-map": "^0.3.3",
 				"acorn": "^8.15.0",
@@ -6789,6 +6877,26 @@
 			"dev": true,
 			"license": "0BSD"
 		},
+		"node_modules/tsx": {
+			"version": "4.23.0",
+			"resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.0.tgz",
+			"integrity": "sha512-eUdUIaCr963q2h5u3+QwvYp0+eqPvn+egeqZUm0hwERCqqx1E3kK5ehbGCvqSE5MQAULr67ww0cA3jKc3YkM1w==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"esbuild": "~0.28.0"
+			},
+			"bin": {
+				"tsx": "dist/cli.mjs"
+			},
+			"engines": {
+				"node": ">=18.0.0"
+			},
+			"optionalDependencies": {
+				"fsevents": "~2.3.3"
+			}
+		},
 		"node_modules/tunnel-agent": {
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -6898,6 +7006,7 @@
 			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
 			"dev": true,
 			"license": "Apache-2.0",
+			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -6960,10 +7069,11 @@
 			}
 		},
 		"node_modules/undici-types": {
-			"version": "6.19.8",
-			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-			"integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-			"dev": true
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+			"integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/uri-js": {
 			"version": "4.4.1",
@@ -6987,6 +7097,7 @@
 			"integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@vitest/expect": "4.1.9",
 				"@vitest/mocker": "4.1.9",
@@ -7104,6 +7215,7 @@
 			"integrity": "sha512-BuJcQK/56NQTWDGn4ABea3q4SSBdNPWwNZKTkkUpcMPnLoquSYH8llRtSUIgoL1KSCpHt5eghLShn50mH36y7Q==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"lightningcss": "^1.32.0",
 				"picomatch": "^4.0.4",
@@ -7180,9 +7292,7 @@
 			"version": "2.2.8",
 			"resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
 			"integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/w3c-xmlserializer": {
 			"version": "5.0.0",
@@ -7530,7 +7640,6 @@
 			"version": "6.5.0",
 			"resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.5.0.tgz",
 			"integrity": "sha512-MwBHVK60IiIHDcoMet78lxt6iw5gJOGSbNbOIVBHWVXIH4/Nq1+GQgLLGgI1KlnN86WDXsPudVaqYHKBIx7Eyw==",
-			"dev": true,
 			"peer": true,
 			"requires": {
 				"@marijn/find-cluster-break": "^1.0.0"
@@ -7540,7 +7649,6 @@
 			"version": "6.38.6",
 			"resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.38.6.tgz",
 			"integrity": "sha512-qiS0z1bKs5WOvHIAC0Cybmv4AJSkAXgX5aD6Mqd2epSLlVJsQl8NG23jCVouIgkh4All/mrbdsf2UOLFnJw0tw==",
-			"dev": true,
 			"peer": true,
 			"requires": {
 				"@codemirror/state": "^6.5.0",
@@ -7577,6 +7685,7 @@
 			"resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
 			"integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
 			"dev": true,
+			"peer": true,
 			"requires": {}
 		},
 		"@csstools/css-syntax-patches-for-csstree": {
@@ -7590,28 +7699,8 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
 			"integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
-			"dev": true
-		},
-		"@emnapi/core": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
-			"integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
 			"dev": true,
-			"optional": true,
-			"requires": {
-				"@emnapi/wasi-threads": "1.2.2",
-				"tslib": "^2.4.0"
-			}
-		},
-		"@emnapi/runtime": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
-			"integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"tslib": "^2.4.0"
-			}
+			"peer": true
 		},
 		"@emnapi/wasi-threads": {
 			"version": "1.2.2",
@@ -8004,9 +8093,7 @@
 		"@marijn/find-cluster-break": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
-			"integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
-			"dev": true,
-			"peer": true
+			"integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g=="
 		},
 		"@microsoft/eslint-plugin-sdl": {
 			"version": "1.1.0",
@@ -8155,6 +8242,29 @@
 				"@emnapi/core": "1.11.1",
 				"@emnapi/runtime": "1.11.1",
 				"@napi-rs/wasm-runtime": "^1.1.6"
+			},
+			"dependencies": {
+				"@emnapi/core": {
+					"version": "1.11.1",
+					"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+					"integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"@emnapi/wasi-threads": "1.2.2",
+						"tslib": "^2.4.0"
+					}
+				},
+				"@emnapi/runtime": {
+					"version": "1.11.1",
+					"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+					"integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"tslib": "^2.4.0"
+					}
+				}
 			}
 		},
 		"@rolldown/binding-win32-arm64-msvc": {
@@ -8226,7 +8336,6 @@
 			"version": "5.60.8",
 			"resolved": "https://registry.npmjs.org/@types/codemirror/-/codemirror-5.60.8.tgz",
 			"integrity": "sha512-VjFgDF/eB+Aklcy15TtOTLQeMjTo07k7KAjql8OK5Dirr7a6sJY4T1uVBDuTVG9VEmn1uUsohOpYnVfgC6/jyw==",
-			"dev": true,
 			"requires": {
 				"@types/tern": "*"
 			}
@@ -8250,8 +8359,7 @@
 		"@types/estree": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
-			"integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
-			"dev": true
+			"integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw=="
 		},
 		"@types/json-schema": {
 			"version": "7.0.15",
@@ -8266,19 +8374,19 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "22.7.9",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.9.tgz",
-			"integrity": "sha512-jrTfRC7FM6nChvU7X2KqcrgquofrWLFDeYC1hKfwNWomVvrn7JIksqf344WN2X/y8xrgqBd2dJATZV4GbatBfg==",
+			"version": "22.20.1",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+			"integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
 			"dev": true,
+			"peer": true,
 			"requires": {
-				"undici-types": "~6.19.2"
+				"undici-types": "~6.21.0"
 			}
 		},
 		"@types/tern": {
 			"version": "0.23.9",
 			"resolved": "https://registry.npmjs.org/@types/tern/-/tern-0.23.9.tgz",
 			"integrity": "sha512-ypzHFE/wBzh+BlH6rrBgS5I/Z7RD21pGhZ2rltb/+ZrVM1awdZwjx7hE5XfuYgHWk9uvV5HLZN3SloevCAp3Bw==",
-			"dev": true,
 			"requires": {
 				"@types/estree": "*"
 			}
@@ -8318,6 +8426,7 @@
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.61.1.tgz",
 			"integrity": "sha512-PJ5vePq5/ognBbrIcoC5+SHO5dfpeLPzP9FpLkzWrguoYQEeeSjlJpVwOpo1JRSTEi7dRcwNy4h4dzV70PqHcg==",
 			"dev": true,
+			"peer": true,
 			"requires": {
 				"@typescript-eslint/scope-manager": "8.61.1",
 				"@typescript-eslint/types": "8.61.1",
@@ -8451,6 +8560,7 @@
 			"resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.9.tgz",
 			"integrity": "sha512-G9/lgqibheLVBDRuya45EbsEXTYcWoSG+TLg7i2axuzx0Eq62eXn+aWXyaVdV5vKvFSWd6ywcX8hA7la9Pvu8g==",
 			"dev": true,
+			"peer": true,
 			"requires": {
 				"@bcoe/v8-coverage": "^1.0.2",
 				"@vitest/utils": "4.1.9",
@@ -8526,11 +8636,29 @@
 				"tinyrainbow": "^3.1.0"
 			}
 		},
+		"@vrtmrz/obsidian-plugin-kit": {
+			"version": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.3/vrtmrz-obsidian-plugin-kit-0.0.0.tgz",
+			"integrity": "sha512-nWPtnxO7wImPmANjSHlka1o62X/MQScCVvmegYtG0jW56fNPUvzLF5cd86RJUdUcTZsgXrk6s3d3N2SdXOR5Xw==",
+			"requires": {
+				"@vrtmrz/ui-interactions": "0.0.0"
+			}
+		},
+		"@vrtmrz/obsidian-test-session": {
+			"version": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.3/vrtmrz-obsidian-test-session-0.0.0.tgz",
+			"integrity": "sha512-XHWFORR8Q7vQsbKxrj8RBgpyC7DHFw5PSUXkBOKJoHnx9abgCkuQp4gYYa64RO7sOdRx/Xj799JOop+McQSqsg==",
+			"dev": true,
+			"requires": {}
+		},
+		"@vrtmrz/ui-interactions": {
+			"version": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.3/vrtmrz-ui-interactions-0.0.0.tgz",
+			"integrity": "sha512-pMFOq2FRKpj0Eq0Jdc1H5gZOv5W0liMNVVAVgpHovA5Bmb8alESjFnS25Y7eapUx6pIbFmbnFeqkhLQGUefCqg=="
+		},
 		"acorn": {
 			"version": "8.15.0",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
 			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"acorn-jsx": {
 			"version": "5.3.2",
@@ -8861,9 +8989,7 @@
 		"crelt": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
-			"integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
-			"dev": true,
-			"peer": true
+			"integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g=="
 		},
 		"cross-spawn": {
 			"version": "7.0.6",
@@ -9182,6 +9308,7 @@
 			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
 			"integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
 			"dev": true,
+			"peer": true,
 			"requires": {
 				"@esbuild/aix-ppc64": "0.28.1",
 				"@esbuild/android-arm": "0.28.1",
@@ -9231,6 +9358,7 @@
 			"resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.1.tgz",
 			"integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
 			"dev": true,
+			"peer": true,
 			"requires": {
 				"@eslint-community/eslint-utils": "^4.8.0",
 				"@eslint-community/regexpp": "^4.12.1",
@@ -10329,6 +10457,7 @@
 			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
 			"integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
 			"dev": true,
+			"peer": true,
 			"requires": {
 				"@asamuzakjp/css-color": "^5.1.11",
 				"@asamuzakjp/dom-selector": "^7.1.1",
@@ -10675,8 +10804,7 @@
 		"moment": {
 			"version": "2.29.4",
 			"resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
-			"integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
-			"dev": true
+			"integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w=="
 		},
 		"mri": {
 			"version": "1.2.0",
@@ -10805,7 +10933,7 @@
 			"version": "1.12.3",
 			"resolved": "https://registry.npmjs.org/obsidian/-/obsidian-1.12.3.tgz",
 			"integrity": "sha512-HxWqe763dOqzXjnNiHmAJTRERN8KILBSqxDSEqbeSr7W8R8Jxezzbca+nz1LiiqXnMpM8lV2jzAezw3CZ4xNUw==",
-			"dev": true,
+			"peer": true,
 			"requires": {
 				"@types/codemirror": "5.60.8",
 				"moment": "2.29.4"
@@ -10912,6 +11040,33 @@
 			"version": "4.0.4",
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
 			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+			"dev": true,
+			"peer": true
+		},
+		"playwright": {
+			"version": "1.61.1",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+			"integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+			"dev": true,
+			"peer": true,
+			"requires": {
+				"fsevents": "2.3.2",
+				"playwright-core": "1.61.1"
+			},
+			"dependencies": {
+				"fsevents": {
+					"version": "2.3.2",
+					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+					"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+					"dev": true,
+					"optional": true
+				}
+			}
+		},
+		"playwright-core": {
+			"version": "1.61.1",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+			"integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
 			"dev": true
 		},
 		"possible-typed-array-names": {
@@ -10925,6 +11080,7 @@
 			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
 			"integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
 			"dev": true,
+			"peer": true,
 			"requires": {
 				"nanoid": "^3.3.12",
 				"picocolors": "^1.1.1",
@@ -11403,9 +11559,7 @@
 		"style-mod": {
 			"version": "4.1.3",
 			"resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
-			"integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
-			"dev": true,
-			"peer": true
+			"integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ=="
 		},
 		"supports-color": {
 			"version": "7.2.0",
@@ -11427,6 +11581,7 @@
 			"resolved": "https://registry.npmjs.org/svelte/-/svelte-5.56.3.tgz",
 			"integrity": "sha512-w7JvrM5IFl5cmfbY0TLik9o7mjRUJmRMhOR51tBPu708Gr/MjbGs7VnJnr/B0CaXeI4vtnOh7RKxDr0cwhMdDA==",
 			"dev": true,
+			"peer": true,
 			"requires": {
 				"@jridgewell/remapping": "^2.3.4",
 				"@jridgewell/sourcemap-codec": "^1.5.0",
@@ -11516,6 +11671,7 @@
 			"resolved": "https://registry.npmjs.org/terser/-/terser-5.44.1.tgz",
 			"integrity": "sha512-t/R3R/n0MSwnnazuPpPNVO60LX0SKL45pyl9YlvxIdkH0Of7D5qM2EVe+yASRIlY5pZ73nclYJfNANGWPwFDZw==",
 			"dev": true,
+			"peer": true,
 			"requires": {
 				"@jridgewell/source-map": "^0.3.3",
 				"acorn": "^8.15.0",
@@ -11618,6 +11774,17 @@
 			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
 			"dev": true
 		},
+		"tsx": {
+			"version": "4.23.0",
+			"resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.0.tgz",
+			"integrity": "sha512-eUdUIaCr963q2h5u3+QwvYp0+eqPvn+egeqZUm0hwERCqqx1E3kK5ehbGCvqSE5MQAULr67ww0cA3jKc3YkM1w==",
+			"dev": true,
+			"peer": true,
+			"requires": {
+				"esbuild": "~0.28.0",
+				"fsevents": "~2.3.3"
+			}
+		},
 		"tunnel-agent": {
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
@@ -11693,7 +11860,8 @@
 			"version": "5.9.3",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
 			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"typescript-eslint": {
 			"version": "8.61.1",
@@ -11726,9 +11894,9 @@
 			"dev": true
 		},
 		"undici-types": {
-			"version": "6.19.8",
-			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-			"integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+			"integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
 			"dev": true
 		},
 		"uri-js": {
@@ -11751,6 +11919,7 @@
 			"resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
 			"integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
 			"dev": true,
+			"peer": true,
 			"requires": {
 				"@vitest/expect": "4.1.9",
 				"@vitest/mocker": "4.1.9",
@@ -11790,6 +11959,7 @@
 					"resolved": "https://registry.npmjs.org/vite/-/vite-8.1.0.tgz",
 					"integrity": "sha512-BuJcQK/56NQTWDGn4ABea3q4SSBdNPWwNZKTkkUpcMPnLoquSYH8llRtSUIgoL1KSCpHt5eghLShn50mH36y7Q==",
 					"dev": true,
+					"peer": true,
 					"requires": {
 						"fsevents": "~2.3.3",
 						"lightningcss": "^1.32.0",
@@ -11804,9 +11974,7 @@
 		"w3c-keyname": {
 			"version": "2.2.8",
 			"resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
-			"integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
-			"dev": true,
-			"peer": true
+			"integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ=="
 		},
 		"w3c-xmlserializer": {
 			"version": "5.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
 			"version": "0.18.16",
 			"license": "MIT",
 			"dependencies": {
-				"@vrtmrz/obsidian-plugin-kit": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.3/vrtmrz-obsidian-plugin-kit-0.0.0.tgz",
-				"@vrtmrz/ui-interactions": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.3/vrtmrz-ui-interactions-0.0.0.tgz"
+				"@vrtmrz/obsidian-plugin-kit": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.5/vrtmrz-obsidian-plugin-kit-0.1.0.tgz",
+				"@vrtmrz/ui-interactions": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.5/vrtmrz-ui-interactions-0.1.0.tgz"
 			},
 			"devDependencies": {
 				"@emnapi/core": "1.11.2",
@@ -20,7 +20,7 @@
 				"@types/node": "^22.20.1",
 				"@typescript-eslint/parser": "^8.48.1",
 				"@vitest/coverage-v8": "^4.1.9",
-				"@vrtmrz/obsidian-test-session": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.3/vrtmrz-obsidian-test-session-0.0.0.tgz",
+				"@vrtmrz/obsidian-test-session": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.5/vrtmrz-obsidian-test-session-0.1.0.tgz",
 				"esbuild": "^0.28.1",
 				"esbuild-svelte": "^0.9.3",
 				"eslint": "^9.39.1",
@@ -2001,21 +2001,21 @@
 			}
 		},
 		"node_modules/@vrtmrz/obsidian-plugin-kit": {
-			"version": "0.0.0",
-			"resolved": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.3/vrtmrz-obsidian-plugin-kit-0.0.0.tgz",
-			"integrity": "sha512-nWPtnxO7wImPmANjSHlka1o62X/MQScCVvmegYtG0jW56fNPUvzLF5cd86RJUdUcTZsgXrk6s3d3N2SdXOR5Xw==",
+			"version": "0.1.0",
+			"resolved": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.5/vrtmrz-obsidian-plugin-kit-0.1.0.tgz",
+			"integrity": "sha512-FttoY0IEt8pbsI3cfAt+qzzg9Ruavka9v7vmBVT/hO1qSSt5ruu6aGS5y21km9qV4PcCmCZOTcDtLTD4ZS+osA==",
 			"license": "MIT",
 			"dependencies": {
-				"@vrtmrz/ui-interactions": "0.0.0"
+				"@vrtmrz/ui-interactions": "0.1.0"
 			},
 			"peerDependencies": {
 				"obsidian": ">=1.8.7"
 			}
 		},
 		"node_modules/@vrtmrz/obsidian-test-session": {
-			"version": "0.0.0",
-			"resolved": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.3/vrtmrz-obsidian-test-session-0.0.0.tgz",
-			"integrity": "sha512-XHWFORR8Q7vQsbKxrj8RBgpyC7DHFw5PSUXkBOKJoHnx9abgCkuQp4gYYa64RO7sOdRx/Xj799JOop+McQSqsg==",
+			"version": "0.1.0",
+			"resolved": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.5/vrtmrz-obsidian-test-session-0.1.0.tgz",
+			"integrity": "sha512-IUM31s7jjhj7S2X6qM7QIvgJX/XzK35878phq/wuLI849BdwfXIliUcnAdqcDN9ajGbLuMkFHy1h2Q2LB0A93A==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -2026,9 +2026,9 @@
 			}
 		},
 		"node_modules/@vrtmrz/ui-interactions": {
-			"version": "0.0.0",
-			"resolved": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.3/vrtmrz-ui-interactions-0.0.0.tgz",
-			"integrity": "sha512-pMFOq2FRKpj0Eq0Jdc1H5gZOv5W0liMNVVAVgpHovA5Bmb8alESjFnS25Y7eapUx6pIbFmbnFeqkhLQGUefCqg==",
+			"version": "0.1.0",
+			"resolved": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.5/vrtmrz-ui-interactions-0.1.0.tgz",
+			"integrity": "sha512-m+15ffZrjrmM7juusfVsp3smeQo1LSPNzIUIRlpnYY4n3PQn5RmM8yR/317LIVGjC41pqhthfRqEJUCNod4c3g==",
 			"license": "MIT"
 		},
 		"node_modules/acorn": {
@@ -8681,21 +8681,21 @@
 			}
 		},
 		"@vrtmrz/obsidian-plugin-kit": {
-			"version": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.3/vrtmrz-obsidian-plugin-kit-0.0.0.tgz",
-			"integrity": "sha512-nWPtnxO7wImPmANjSHlka1o62X/MQScCVvmegYtG0jW56fNPUvzLF5cd86RJUdUcTZsgXrk6s3d3N2SdXOR5Xw==",
+			"version": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.5/vrtmrz-obsidian-plugin-kit-0.1.0.tgz",
+			"integrity": "sha512-FttoY0IEt8pbsI3cfAt+qzzg9Ruavka9v7vmBVT/hO1qSSt5ruu6aGS5y21km9qV4PcCmCZOTcDtLTD4ZS+osA==",
 			"requires": {
-				"@vrtmrz/ui-interactions": "0.0.0"
+				"@vrtmrz/ui-interactions": "0.1.0"
 			}
 		},
 		"@vrtmrz/obsidian-test-session": {
-			"version": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.3/vrtmrz-obsidian-test-session-0.0.0.tgz",
-			"integrity": "sha512-XHWFORR8Q7vQsbKxrj8RBgpyC7DHFw5PSUXkBOKJoHnx9abgCkuQp4gYYa64RO7sOdRx/Xj799JOop+McQSqsg==",
+			"version": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.5/vrtmrz-obsidian-test-session-0.1.0.tgz",
+			"integrity": "sha512-IUM31s7jjhj7S2X6qM7QIvgJX/XzK35878phq/wuLI849BdwfXIliUcnAdqcDN9ajGbLuMkFHy1h2Q2LB0A93A==",
 			"dev": true,
 			"requires": {}
 		},
 		"@vrtmrz/ui-interactions": {
-			"version": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.3/vrtmrz-ui-interactions-0.0.0.tgz",
-			"integrity": "sha512-pMFOq2FRKpj0Eq0Jdc1H5gZOv5W0liMNVVAVgpHovA5Bmb8alESjFnS25Y7eapUx6pIbFmbnFeqkhLQGUefCqg=="
+			"version": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.5/vrtmrz-ui-interactions-0.1.0.tgz",
+			"integrity": "sha512-m+15ffZrjrmM7juusfVsp3smeQo1LSPNzIUIRlpnYY4n3PQn5RmM8yR/317LIVGjC41pqhthfRqEJUCNod4c3g=="
 		},
 		"acorn": {
 			"version": "8.15.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
 	"author": "vorotamoroz",
 	"license": "MIT",
 	"devDependencies": {
+		"@emnapi/core": "1.11.2",
+		"@emnapi/runtime": "1.11.2",
 		"@eslint/js": "^9.39.1",
 		"@tsconfig/svelte": "^5.0.4",
 		"@types/node": "^22.20.1",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
 		"coverage": "vitest run --coverage",
 		"svelte-check": "svelte-check --tsconfig ./tsconfig.json",
 		"tsc-check": "tsc --noEmit",
+		"check:e2e:obsidian": "tsc -p test/e2e-obsidian/tsconfig.json",
+		"test:e2e:obsidian:new-note-template": "npm run build && tsx test/e2e-obsidian/new-note-template.mts",
 		"check": "npm run lint && npm run test && npm run svelte-check && npm run tsc-check",
 		"version": "node version-bump.mjs"
 	},
@@ -21,9 +23,10 @@
 	"devDependencies": {
 		"@eslint/js": "^9.39.1",
 		"@tsconfig/svelte": "^5.0.4",
-		"@types/node": "^22.7.9",
+		"@types/node": "^22.20.1",
 		"@typescript-eslint/parser": "^8.48.1",
 		"@vitest/coverage-v8": "^4.1.9",
+		"@vrtmrz/obsidian-test-session": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.3/vrtmrz-obsidian-test-session-0.0.0.tgz",
 		"esbuild": "^0.28.1",
 		"esbuild-svelte": "^0.9.3",
 		"eslint": "^9.39.1",
@@ -32,12 +35,18 @@
 		"globals": "^14.0.0",
 		"jsdom": "^29.1.1",
 		"obsidian": "^1.10.3",
+		"playwright": "^1.61.1",
 		"svelte": "^5.45.5",
 		"svelte-check": "^4.3.4",
 		"svelte-eslint-parser": "^1.8.0",
 		"svelte-preprocess": "^6.0.3",
 		"terser": "^5.44.1",
+		"tsx": "^4.23.0",
 		"typescript": "^5.9.3",
 		"vitest": "^4.1.9"
+	},
+	"dependencies": {
+		"@vrtmrz/obsidian-plugin-kit": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.3/vrtmrz-obsidian-plugin-kit-0.0.0.tgz",
+		"@vrtmrz/ui-interactions": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.3/vrtmrz-ui-interactions-0.0.0.tgz"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
 		"@types/node": "^22.20.1",
 		"@typescript-eslint/parser": "^8.48.1",
 		"@vitest/coverage-v8": "^4.1.9",
-		"@vrtmrz/obsidian-test-session": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.3/vrtmrz-obsidian-test-session-0.0.0.tgz",
+		"@vrtmrz/obsidian-test-session": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.5/vrtmrz-obsidian-test-session-0.1.0.tgz",
 		"esbuild": "^0.28.1",
 		"esbuild-svelte": "^0.9.3",
 		"eslint": "^9.39.1",
@@ -48,7 +48,7 @@
 		"vitest": "^4.1.9"
 	},
 	"dependencies": {
-		"@vrtmrz/obsidian-plugin-kit": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.3/vrtmrz-obsidian-plugin-kit-0.0.0.tgz",
-		"@vrtmrz/ui-interactions": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.3/vrtmrz-ui-interactions-0.0.0.tgz"
+		"@vrtmrz/obsidian-plugin-kit": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.5/vrtmrz-obsidian-plugin-kit-0.1.0.tgz",
+		"@vrtmrz/ui-interactions": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.5/vrtmrz-ui-interactions-0.1.0.tgz"
 	}
 }

--- a/test/e2e-obsidian/README.md
+++ b/test/e2e-obsidian/README.md
@@ -1,0 +1,14 @@
+# Real Obsidian E2E
+
+This local-only suite installs the built TagFolder plug-in into an isolated vault and profile through `@vrtmrz/obsidian-test-session`. It is not part of the default CI gate.
+
+The new-note scenario selects a seeded template through the real Obsidian picker, verifies its secondary path description, creates a note through TagFolder, and checks the resulting Vault content. It does not use scripted UI or Vault responses.
+
+The suite is currently validated on Linux only. Set `OBSIDIAN_BINARY` and `OBSIDIAN_CLI` when the executables are outside the shared discovery paths.
+
+```bash
+npm run check:e2e:obsidian
+npm run test:e2e:obsidian:new-note-template
+```
+
+Set `E2E_OBSIDIAN_KEEP_VAULT=true` to preserve the temporary vault and isolated application state for debugging.

--- a/test/e2e-obsidian/harness.mts
+++ b/test/e2e-obsidian/harness.mts
@@ -1,0 +1,57 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { join, resolve } from "node:path";
+import {
+	createTemporaryVault,
+	discoverObsidianCli,
+	requireObsidianBinary,
+	startObsidianPluginSession,
+	type ObsidianPluginSession,
+	type TemporaryVault,
+} from "@vrtmrz/obsidian-test-session";
+
+export const TAGFOLDER_PLUGIN_ID = "obsidian-tagfolder";
+
+export interface TagFolderTestSession {
+	readonly session: ObsidianPluginSession;
+	readonly vault: TemporaryVault;
+}
+
+async function seedTemplate(vaultPath: string): Promise<void> {
+	const templatesPath = join(vaultPath, "Templates");
+	await mkdir(templatesPath, { recursive: true });
+	await writeFile(
+		join(templatesPath, "Project note.md"),
+		"# {{tagName}}\n\n{{expandedTags}}",
+		"utf8",
+	);
+}
+
+export async function startTagFolderTestSession(): Promise<TagFolderTestSession> {
+	const cli = discoverObsidianCli();
+	if (!cli.binary) throw new Error(`Could not find obsidian-cli. Checked: ${cli.checked.join(", ")}`);
+	const vault = await createTemporaryVault({
+		prefix: "tagfolder-e2e-",
+		pluginIds: [TAGFOLDER_PLUGIN_ID],
+		idPrefix: "tagfolder-e2e",
+	});
+	try {
+		await seedTemplate(vault.path);
+		const session = await startObsidianPluginSession({
+			binary: requireObsidianBinary(),
+			cliBinary: cli.binary,
+			vault,
+			pluginId: TAGFOLDER_PLUGIN_ID,
+			artifactRoot: resolve("."),
+			startupGraceMs: Number(process.env.E2E_OBSIDIAN_STARTUP_GRACE_MS ?? 1_000),
+		});
+		return { session, vault };
+	} catch (error) {
+		await vault.dispose();
+		throw error;
+	}
+}
+
+export async function stopTagFolderTestSession(testSession: TagFolderTestSession): Promise<void> {
+	await testSession.session.app.stop();
+	await testSession.vault.dispose();
+}

--- a/test/e2e-obsidian/new-note-template.mts
+++ b/test/e2e-obsidian/new-note-template.mts
@@ -1,0 +1,85 @@
+import { withObsidianPage } from "@vrtmrz/obsidian-test-session";
+import {
+	TAGFOLDER_PLUGIN_ID,
+	startTagFolderTestSession,
+	stopTagFolderTestSession,
+	type TagFolderTestSession,
+} from "./harness.mts";
+
+async function verifyTemplateWorkflow(testSession: TagFolderTestSession): Promise<void> {
+	await withObsidianPage(testSession.session.remoteDebuggingPort, async (page) => {
+		const creation = page.evaluate(async (pluginId) => {
+			const obsidianApp = (
+				globalThis as typeof globalThis & {
+					app?: {
+						plugins?: {
+							plugins?: Record<
+								string,
+								{
+									settings: {
+										newNoteTemplate: string;
+										useFrontmatterTagsForNewNotes: boolean;
+									};
+									createNewNote(tags: string[]): Promise<void>;
+								}
+							>;
+						};
+					};
+				}
+			).app;
+			const plugin = obsidianApp?.plugins?.plugins?.[pluginId];
+			if (!plugin) throw new Error(`TagFolder is not loaded: ${pluginId}`);
+			plugin.settings.newNoteTemplate = "Templates/missing";
+			plugin.settings.useFrontmatterTagsForNewNotes = false;
+			await plugin.createNewNote(["project/client"]);
+		}, TAGFOLDER_PLUGIN_ID);
+
+		const prompt = page.locator(".prompt").last();
+		await prompt.waitFor({ state: "visible", timeout: 10_000 });
+		const templateItem = prompt
+			.locator(".suggestion-item")
+			.filter({ hasText: "Project note" })
+			.filter({ hasText: "Templates/Project note.md" });
+		await templateItem.waitFor();
+		await templateItem.click();
+		await creation;
+
+		const created = await page.evaluate(async () => {
+			const obsidianApp = (
+				globalThis as typeof globalThis & {
+					app?: {
+						vault?: {
+							getMarkdownFiles(): Array<{ path: string }>;
+							read(file: { path: string }): Promise<string>;
+						};
+					};
+				}
+			).app;
+			const vault = obsidianApp?.vault;
+			if (!vault) throw new Error("Obsidian Vault is unavailable");
+			const file = vault.getMarkdownFiles().find((candidate) => !candidate.path.startsWith("Templates/"));
+			if (!file) throw new Error("TagFolder did not create a note");
+			return { path: file.path, content: await vault.read(file) };
+		});
+
+		if (created.content !== "# project/client\n\n#project/client") {
+			throw new Error(`Unexpected created note ${created.path}: ${JSON.stringify(created.content)}`);
+		}
+	});
+}
+
+async function main(): Promise<void> {
+	let testSession: TagFolderTestSession | undefined;
+	try {
+		testSession = await startTagFolderTestSession();
+		await verifyTemplateWorkflow(testSession);
+		console.log("TagFolder template selection and Vault write passed in real Obsidian");
+	} finally {
+		if (testSession) await stopTagFolderTestSession(testSession);
+	}
+}
+
+main().catch((error: unknown) => {
+	console.error(error instanceof Error ? error.stack : error);
+	process.exit(1);
+});

--- a/test/e2e-obsidian/tsconfig.json
+++ b/test/e2e-obsidian/tsconfig.json
@@ -1,0 +1,14 @@
+{
+	"compilerOptions": {
+		"target": "ES2022",
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"lib": ["ES2022", "DOM"],
+		"types": ["node"],
+		"allowImportingTsExtensions": true,
+		"strict": true,
+		"skipLibCheck": true,
+		"noEmit": true
+	},
+	"include": ["**/*.mts"]
+}

--- a/tests/new-note-workflow.test.ts
+++ b/tests/new-note-workflow.test.ts
@@ -1,0 +1,106 @@
+import {
+	createUiTestHarness,
+	createVaultTextTestHarness,
+} from "@vrtmrz/obsidian-plugin-kit/testing";
+import { describe, expect, it, vi } from "vitest";
+import {
+	chooseNewNoteTemplate,
+	NEW_NOTE_TEMPLATE_INTERACTION_ID,
+	populateNewNote,
+	type NewNoteTemplateChoice,
+} from "../new-note-workflow";
+
+const template: NewNoteTemplateChoice = {
+	name: "Project note",
+	path: "Templates/project.md",
+};
+
+describe("new-note workflow", () => {
+	it("selects a template by identity and records its read and rendered note write", async () => {
+		const ui = createUiTestHarness([
+			{ kind: "pickOne", interactionId: NEW_NOTE_TEMPLATE_INTERACTION_ID, value: template },
+		]);
+		const vault = createVaultTextTestHarness({
+			files: {
+				[template.path]: "# {{tagName}}\n\n{{expandedTags}}",
+				"Untitled.md": "",
+			},
+		});
+
+		const selected = await chooseNewNoteTemplate(ui.ui, [template]);
+		await populateNewNote({
+			vault: vault.vault,
+			notePath: "Untitled.md",
+			template: selected,
+			expandedTagsAll: ["project/client"],
+			expandedTags: "#project/client",
+			frontmatterTags: ["project/client"],
+			useFrontmatterTags: false,
+			applyFrontmatterTags: vi.fn(),
+		});
+
+		expect(ui.transcript).toEqual([
+			{
+				kind: "pickOne",
+				interactionId: NEW_NOTE_TEMPLATE_INTERACTION_ID,
+				options: expect.objectContaining({
+					items: [template],
+					placeholder: "Type to search templates...",
+				}),
+			},
+		]);
+		expect(vault.transcript).toEqual([
+			{ kind: "readText", path: template.path },
+			{
+				kind: "modifyText",
+				path: "Untitled.md",
+				content: "# project/client\n\n#project/client",
+			},
+		]);
+		expect(vault.getFile("Untitled.md")).toBe("# project/client\n\n#project/client");
+		ui.assertDone();
+	});
+
+	it("falls back to appending tags when template selection is dismissed", async () => {
+		const ui = createUiTestHarness([
+			{ kind: "pickOne", interactionId: NEW_NOTE_TEMPLATE_INTERACTION_ID, value: null },
+		]);
+		const vault = createVaultTextTestHarness({ files: { "Untitled.md": "" } });
+
+		const selected = await chooseNewNoteTemplate(ui.ui, [template]);
+		await populateNewNote({
+			vault: vault.vault,
+			notePath: "Untitled.md",
+			template: selected,
+			expandedTagsAll: ["project/client"],
+			expandedTags: "#project/client",
+			frontmatterTags: ["project/client"],
+			useFrontmatterTags: false,
+			applyFrontmatterTags: vi.fn(),
+		});
+
+		expect(vault.transcript).toEqual([
+			{ kind: "appendText", path: "Untitled.md", content: "#project/client" },
+		]);
+		ui.assertDone();
+	});
+
+	it("delegates frontmatter mutation without issuing a text write", async () => {
+		const vault = createVaultTextTestHarness({ files: { "Untitled.md": "" } });
+		const applyFrontmatterTags = vi.fn<(tags: readonly string[]) => Promise<void>>(async () => {});
+
+		await populateNewNote({
+			vault: vault.vault,
+			notePath: "Untitled.md",
+			template: null,
+			expandedTagsAll: ["project/client"],
+			expandedTags: "#project/client",
+			frontmatterTags: ["project/client"],
+			useFrontmatterTags: true,
+			applyFrontmatterTags,
+		});
+
+		expect(applyFrontmatterTags).toHaveBeenCalledWith(["project/client"]);
+		expect(vault.transcript).toEqual([]);
+	});
+});

--- a/tests/new-note-workflow.test.ts
+++ b/tests/new-note-workflow.test.ts
@@ -5,6 +5,7 @@ import {
 import { describe, expect, it, vi } from "vitest";
 import {
 	chooseNewNoteTemplate,
+	filterNewNoteTemplateChoices,
 	NEW_NOTE_TEMPLATE_INTERACTION_ID,
 	populateNewNote,
 	type NewNoteTemplateChoice,
@@ -16,6 +17,25 @@ const template: NewNoteTemplateChoice = {
 };
 
 describe("new-note workflow", () => {
+	it("filters one captured template snapshot by name or path", () => {
+		const otherTemplate: NewNoteTemplateChoice = {
+			name: "Meeting note",
+			path: "Templates/meetings/daily.md",
+		};
+		const snapshot = [template, otherTemplate];
+
+		expect(filterNewNoteTemplateChoices(snapshot, "PROJECT")).toEqual([template]);
+		expect(filterNewNoteTemplateChoices(snapshot, "meetings/")).toEqual([otherTemplate]);
+		expect(snapshot).toEqual([template, otherTemplate]);
+	});
+
+	it("requests a retry without opening UI when the captured snapshot is empty", async () => {
+		const ui = createUiTestHarness([]);
+
+		await expect(chooseNewNoteTemplate(ui.ui, [])).resolves.toBeUndefined();
+		ui.assertDone();
+	});
+
 	it("selects a template by identity and records its read and rendered note write", async () => {
 		const ui = createUiTestHarness([
 			{ kind: "pickOne", interactionId: NEW_NOTE_TEMPLATE_INTERACTION_ID, value: template },
@@ -28,6 +48,8 @@ describe("new-note workflow", () => {
 		});
 
 		const selected = await chooseNewNoteTemplate(ui.ui, [template]);
+		expect(selected).not.toBeUndefined();
+		if (selected === undefined) throw new Error("Expected a captured template selection");
 		await populateNewNote({
 			vault: vault.vault,
 			notePath: "Untitled.md",
@@ -68,6 +90,8 @@ describe("new-note workflow", () => {
 		const vault = createVaultTextTestHarness({ files: { "Untitled.md": "" } });
 
 		const selected = await chooseNewNoteTemplate(ui.ui, [template]);
+		expect(selected).not.toBeUndefined();
+		if (selected === undefined) throw new Error("Expected a dismissed template selection");
 		await populateNewNote({
 			vault: vault.vault,
 			notePath: "Untitled.md",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
         "target": "ES2018",
 		"allowJs": true,
 		"noImplicitAny": true,
-		"moduleResolution": "node",
+		"moduleResolution": "bundler",
 		"types": ["svelte", "node"],
 		// "importsNotUsedAsValues": "error",
 		"importHelpers": false,


### PR DESCRIPTION
## What changed

- replace the custom new-note template `SuggestModal` with the instance-scoped Fancy Kit UI capability
- route template reads and new-note text writes through the Fancy Kit Vault text capability
- extract the consumer-owned new-note workflow and cover it with App-free UI/Vault harness tests
- capture template suggestions once when the settings tab or new-note selection dialog opens, rather than enumerating and sorting the Vault on every settings query
- add a local-only real-Obsidian scenario for template selection and persisted Vault content
- pin the UI, plug-in kit, and test-session packages to one immutable Fancy Kit preview release
- keep the root README user-facing and move implementation and validation details to `docs/devs.md`

## Why

The new-note flow previously coupled template selection, Obsidian file access, and TagFolder policy in the plug-in class. Explicit UI and Vault capabilities keep TagFolder's policy local while making the application workflow injectable and observable in consumer tests.

The visible template selector still shows the template name and Vault-relative path. Cancellation, frontmatter handling, template rendering, and hashtag fallback remain TagFolder-owned behaviour. Suggestion snapshots deliberately refresh when the settings tab or new-note selection dialog is reopened; no Vault watcher is installed.

## Preview dependency

The three Fancy Kit packages are pinned together to `consumer-preview-2026-07-10.5`; scoped packages report version `0.1.0`.

## Validation

- clean `npm ci`; zero vulnerabilities
- `npm run check` — 30 tests, lint, Svelte diagnostics, and TypeScript
- `npm run check:e2e:obsidian`
- `npm run build`
- the existing real-Obsidian template-selection scenario passed on Linux before the snapshot follow-up
- the snapshot follow-up is covered by unit/check/build validation and awaits BRAT actual-device verification

## BRAT manual gate

The frozen `0.18.17-fancy.2` pre-release must pass before merge.

- [x] Record Obsidian version, BRAT version, OS/device, and test date
- [x] Install through BRAT, enable TagFolder, reload Obsidian, and confirm settings and tag views are preserved without new errors
- [x] Open TagFolder settings and confirm typing in **Template for new notes** remains responsive
- [x] Add a template while settings remain open, reopen the settings tab, and confirm the refreshed suggestion appears
- [x] Configure at least two core Templates and set **Template for new notes** to a non-existent, non-empty path
- [x] Create a note from a TagFolder tag context and confirm the new-note template selection dialog shows each template name and Vault-relative path
- [x] Select a template and confirm rendered content and tag variables such as `{{tagName}}` and `{{expandedTags}}` are persisted
- [x] Dismiss the selection dialog and confirm hashtag fallback when frontmatter storage is disabled
- [x] Dismiss the selection dialog and confirm Properties fallback when frontmatter storage is enabled
- [x] Configure a valid template path and confirm it is applied without opening the selection dialog
- [x] Confirm existing notes and templates are not modified
- [x] Complete the workflow on desktop and mobile, then record the results here before merge
