### PR TITLE
Release 0.18.17

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "id": "obsidian-tagfolder",
     "name": "TagFolder",
-    "version": "0.18.16",
+    "version": "0.18.17",
     "minAppVersion": "1.7.2",
     "description": "Show tags as folder.",
     "author": "vorotamoroz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "obsidian-tagfolder",
-	"version": "0.18.16",
+	"version": "0.18.17",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "obsidian-tagfolder",
-			"version": "0.18.16",
+			"version": "0.18.17",
 			"license": "MIT",
 			"dependencies": {
 				"@vrtmrz/obsidian-plugin-kit": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.5/vrtmrz-obsidian-plugin-kit-0.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "obsidian-tagfolder",
-	"version": "0.18.16",
+	"version": "0.18.17",
 	"description": "Show tags as folder.",
 	"main": "main.js",
 	"type": "module",

--- a/updates.md
+++ b/updates.md
@@ -1,3 +1,17 @@
+## 0.18.17
+
+### Improved
+
+-   Improved new-note template selection so that suggestions show both the template name and its Vault-relative path.
+-   Template suggestions in the settings tab are now captured when the tab opens, avoiding repeated Vault enumeration and sorting while typing.
+-   The new-note template selection dialogue captures a fresh template list each time it opens, without installing a Vault watcher.
+-   When no templates are available, TagFolder now asks for the action to be retried after a template has been added, instead of creating a note without the requested template.
+
+### Digging the weeds
+
+-   Refactored UI interactions and Vault text operations into explicit Fancy Kit capabilities.
+-   Added App-free workflow tests and a local real-Obsidian scenario for template selection and persisted note content.
+
 ## 0.18.16
 
 ### Fixes


### PR DESCRIPTION
## Summary

- bump the plug-in, package, and lockfile versions from `0.18.16` to `0.18.17`
- add the `0.18.17` user-facing changelog entry
- release the Fancy Kit UI/Vault adoption and template-snapshot improvements already merged through #144

## Validation

- clean `npm ci`; zero vulnerabilities
- `npm run check` — 30 tests, lint, Svelte diagnostics, and TypeScript
- `npm run check:e2e:obsidian`
- `npm run build`
- release PR CI and tag-triggered release workflow passed
- `main.js` and `styles.css` are byte-for-byte identical to the BRAT-verified `0.18.17-fancy.2` build
- only `manifest.json` changes between the preview and final distributable, replacing the preview version with `0.18.17`

## Release gate

The [`0.18.17` pre-release](https://github.com/vrtmrz/obsidian-tagfolder/releases/tag/0.18.17) was created from this pull request head before merge so that BRAT tests the exact commit intended for `main`.

- [x] Confirm the `0.18.17` tag points to this pull request head (`b83411f`)
- [x] Confirm the release workflow succeeds
- [x] Confirm the release provides `main.js`, `manifest.json`, and `styles.css` as direct assets
- [x] Install `0.18.17` through BRAT and confirm the manifest reports `0.18.17`
- [x] Enable TagFolder, reload Obsidian, and confirm it starts without new errors
- [x] Confirm existing settings, tag views, and template configuration are preserved
- [x] Confirm the new-note template selection dialogue and settings suggestions still work
- [x] Record the Obsidian version, BRAT version, OS/device, and test date
- [x] Merge this pull request only after the BRAT installation succeeds
- [x] After merge, promote the verified release from pre-release to stable `Latest`
