### PR TITLE
Use stable Fancy Kit packages

### DIFF
--- a/docs/devs.md
+++ b/docs/devs.md
@@ -41,9 +41,9 @@ The UI transcript verifies the stable interaction ID and selected object identit
 
 The path-based Vault capability deliberately does not replace real Obsidian coverage for `TFile` identity, Vault events, MetadataCache propagation, or frontmatter processing.
 
-## Fancy Kit preview
+## Fancy Kit dependencies
 
-Until Fancy Kit is published to npm, its packages are pinned to immutable tarballs from one GitHub prerelease. Update the UI interactions, Obsidian plug-in kit, and test-session URLs together when a migration needs a newer preview.
+The three Fancy Kit packages are pinned to exact npm versions so the tested dependency set remains reproducible. Review and update the UI interactions, Obsidian plug-in kit, and test-session versions together when adopting a newer contract.
 
 Real-Obsidian scenarios are local-only and currently validated on Linux only.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
 			"version": "0.18.17",
 			"license": "MIT",
 			"dependencies": {
-				"@vrtmrz/obsidian-plugin-kit": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.5/vrtmrz-obsidian-plugin-kit-0.1.0.tgz",
-				"@vrtmrz/ui-interactions": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.5/vrtmrz-ui-interactions-0.1.0.tgz"
+				"@vrtmrz/obsidian-plugin-kit": "0.1.0",
+				"@vrtmrz/ui-interactions": "0.1.0"
 			},
 			"devDependencies": {
 				"@emnapi/core": "1.11.2",
@@ -20,7 +20,7 @@
 				"@types/node": "^22.20.1",
 				"@typescript-eslint/parser": "^8.48.1",
 				"@vitest/coverage-v8": "^4.1.9",
-				"@vrtmrz/obsidian-test-session": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.5/vrtmrz-obsidian-test-session-0.1.0.tgz",
+				"@vrtmrz/obsidian-test-session": "0.1.0",
 				"esbuild": "^0.28.1",
 				"esbuild-svelte": "^0.9.3",
 				"eslint": "^9.39.1",
@@ -2002,8 +2002,8 @@
 		},
 		"node_modules/@vrtmrz/obsidian-plugin-kit": {
 			"version": "0.1.0",
-			"resolved": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.5/vrtmrz-obsidian-plugin-kit-0.1.0.tgz",
-			"integrity": "sha512-FttoY0IEt8pbsI3cfAt+qzzg9Ruavka9v7vmBVT/hO1qSSt5ruu6aGS5y21km9qV4PcCmCZOTcDtLTD4ZS+osA==",
+			"resolved": "https://registry.npmjs.org/@vrtmrz/obsidian-plugin-kit/-/obsidian-plugin-kit-0.1.0.tgz",
+			"integrity": "sha512-TFuqbP+HcxFhd9zvgvSkEvLa1B49omGaOmJ5V06xyECOK696UTzH7NHfTc8+/Ji6JB9QB48cAfQ9A6kKiLxGnA==",
 			"license": "MIT",
 			"dependencies": {
 				"@vrtmrz/ui-interactions": "0.1.0"
@@ -2014,21 +2014,22 @@
 		},
 		"node_modules/@vrtmrz/obsidian-test-session": {
 			"version": "0.1.0",
-			"resolved": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.5/vrtmrz-obsidian-test-session-0.1.0.tgz",
-			"integrity": "sha512-IUM31s7jjhj7S2X6qM7QIvgJX/XzK35878phq/wuLI849BdwfXIliUcnAdqcDN9ajGbLuMkFHy1h2Q2LB0A93A==",
+			"resolved": "https://registry.npmjs.org/@vrtmrz/obsidian-test-session/-/obsidian-test-session-0.1.0.tgz",
+			"integrity": "sha512-asBOIRTc3xK5GF5ds5mkxN6vsO4RE8o7puvVjoJiGYSlxoFa9jzr8FwAO13CyoOriHF05pOZfTB+eQmL1aNb/A==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=20"
 			},
 			"peerDependencies": {
+				"@types/node": ">=20",
 				"playwright": ">=1.50.0"
 			}
 		},
 		"node_modules/@vrtmrz/ui-interactions": {
 			"version": "0.1.0",
-			"resolved": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.5/vrtmrz-ui-interactions-0.1.0.tgz",
-			"integrity": "sha512-m+15ffZrjrmM7juusfVsp3smeQo1LSPNzIUIRlpnYY4n3PQn5RmM8yR/317LIVGjC41pqhthfRqEJUCNod4c3g==",
+			"resolved": "https://registry.npmjs.org/@vrtmrz/ui-interactions/-/ui-interactions-0.1.0.tgz",
+			"integrity": "sha512-2K+DgrEdH+MaNXQOZySSfGkYTc8xMlOuaHXX/tZOC/CC8AgPF9+SjjmgpO8hZeZUZiYC2vevdGvS0yxOh1Jnjw==",
 			"license": "MIT"
 		},
 		"node_modules/acorn": {
@@ -8681,21 +8682,24 @@
 			}
 		},
 		"@vrtmrz/obsidian-plugin-kit": {
-			"version": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.5/vrtmrz-obsidian-plugin-kit-0.1.0.tgz",
-			"integrity": "sha512-FttoY0IEt8pbsI3cfAt+qzzg9Ruavka9v7vmBVT/hO1qSSt5ruu6aGS5y21km9qV4PcCmCZOTcDtLTD4ZS+osA==",
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/@vrtmrz/obsidian-plugin-kit/-/obsidian-plugin-kit-0.1.0.tgz",
+			"integrity": "sha512-TFuqbP+HcxFhd9zvgvSkEvLa1B49omGaOmJ5V06xyECOK696UTzH7NHfTc8+/Ji6JB9QB48cAfQ9A6kKiLxGnA==",
 			"requires": {
 				"@vrtmrz/ui-interactions": "0.1.0"
 			}
 		},
 		"@vrtmrz/obsidian-test-session": {
-			"version": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.5/vrtmrz-obsidian-test-session-0.1.0.tgz",
-			"integrity": "sha512-IUM31s7jjhj7S2X6qM7QIvgJX/XzK35878phq/wuLI849BdwfXIliUcnAdqcDN9ajGbLuMkFHy1h2Q2LB0A93A==",
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/@vrtmrz/obsidian-test-session/-/obsidian-test-session-0.1.0.tgz",
+			"integrity": "sha512-asBOIRTc3xK5GF5ds5mkxN6vsO4RE8o7puvVjoJiGYSlxoFa9jzr8FwAO13CyoOriHF05pOZfTB+eQmL1aNb/A==",
 			"dev": true,
 			"requires": {}
 		},
 		"@vrtmrz/ui-interactions": {
-			"version": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.5/vrtmrz-ui-interactions-0.1.0.tgz",
-			"integrity": "sha512-m+15ffZrjrmM7juusfVsp3smeQo1LSPNzIUIRlpnYY4n3PQn5RmM8yR/317LIVGjC41pqhthfRqEJUCNod4c3g=="
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/@vrtmrz/ui-interactions/-/ui-interactions-0.1.0.tgz",
+			"integrity": "sha512-2K+DgrEdH+MaNXQOZySSfGkYTc8xMlOuaHXX/tZOC/CC8AgPF9+SjjmgpO8hZeZUZiYC2vevdGvS0yxOh1Jnjw=="
 		},
 		"acorn": {
 			"version": "8.15.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
 		"@types/node": "^22.20.1",
 		"@typescript-eslint/parser": "^8.48.1",
 		"@vitest/coverage-v8": "^4.1.9",
-		"@vrtmrz/obsidian-test-session": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.5/vrtmrz-obsidian-test-session-0.1.0.tgz",
+		"@vrtmrz/obsidian-test-session": "0.1.0",
 		"esbuild": "^0.28.1",
 		"esbuild-svelte": "^0.9.3",
 		"eslint": "^9.39.1",
@@ -48,7 +48,7 @@
 		"vitest": "^4.1.9"
 	},
 	"dependencies": {
-		"@vrtmrz/obsidian-plugin-kit": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.5/vrtmrz-obsidian-plugin-kit-0.1.0.tgz",
-		"@vrtmrz/ui-interactions": "https://github.com/vrtmrz/fancy-kit/releases/download/consumer-preview-2026-07-10.5/vrtmrz-ui-interactions-0.1.0.tgz"
+		"@vrtmrz/obsidian-plugin-kit": "0.1.0",
+		"@vrtmrz/ui-interactions": "0.1.0"
 	}
 }


### PR DESCRIPTION
## Summary

- replace the three Fancy Kit preview tarballs with exact `0.1.0` npm registry versions
- update the developer guide to describe the reproducible stable dependency set

## Why

The Fancy Kit packages have completed staged publication, provenance verification, and consumer validation. TagFolder can now consume the reviewed stable registry artefacts instead of immutable GitHub preview assets.

This changes dependency resolution only. There is no intended user-facing behaviour change, and the production plug-in artefacts remain unchanged from `main`.

## Validation

- [x] `npm ci` with no reported vulnerabilities
- [x] `npm run check` (30 tests, Svelte 0 warnings, TypeScript, and lint)
- [x] `npm run build`
- [x] `npm run check:e2e:obsidian`
- [x] real-Obsidian template selection and Vault write scenario on Linux
- [x] confirmed that `main.js`, `manifest.json`, and `styles.css` remain unchanged
- [x] GitHub CI after the registry update

The real-Obsidian run used the local-only isolated-vault harness and Obsidian 1.12.7.
