### PR TITLE
Narrow new-note workflow capabilities

### DIFF
--- a/new-note-workflow.ts
+++ b/new-note-workflow.ts
@@ -4,6 +4,15 @@ import { renderTagFolderTemplateVariables } from "./new-note-template";
 
 export const NEW_NOTE_TEMPLATE_INTERACTION_ID = "new-note-template";
 
+/** UI capability required by the new-note template workflow. */
+export type NewNoteTemplateUi = Pick<UiInteractions, "pickOne">;
+
+/** Vault text capability required while populating a new note. */
+export type NewNoteVaultTextAccess = Pick<
+	VaultTextAccess,
+	"readText" | "modifyText" | "appendText"
+>;
+
 /** Template identity and labels exposed to the application workflow. */
 export interface NewNoteTemplateChoice {
 	/** Vault-relative template path. */
@@ -26,7 +35,7 @@ export function filterNewNoteTemplateChoices(
 
 /** Requests one captured template by identity, returns `null` when dismissed, or `undefined` when empty. */
 export async function chooseNewNoteTemplate(
-	ui: UiInteractions,
+	ui: NewNoteTemplateUi,
 	templates: readonly NewNoteTemplateChoice[],
 ): Promise<NewNoteTemplateChoice | null | undefined> {
 	if (templates.length == 0) return undefined;
@@ -44,7 +53,7 @@ export async function chooseNewNoteTemplate(
 /** Inputs owned by TagFolder while populating a newly created note. */
 export interface PopulateNewNoteOptions {
 	/** Injectable path-based Vault text capability. */
-	readonly vault: VaultTextAccess;
+	readonly vault: NewNoteVaultTextAccess;
 	/** Vault-relative path of the already created note. */
 	readonly notePath: string;
 	/** Selected template, or `null` to apply tags without a template. */

--- a/tests/new-note-workflow.test.ts
+++ b/tests/new-note-workflow.test.ts
@@ -127,4 +127,34 @@ describe("new-note workflow", () => {
 		expect(applyFrontmatterTags).toHaveBeenCalledWith(["project/client"]);
 		expect(vault.transcript).toEqual([]);
 	});
+
+	it("propagates a Vault write failure without changing the note", async () => {
+		const writeFailure = new Error("Vault write failed");
+		const vault = createVaultTextTestHarness({
+			files: {
+				[template.path]: "# {{tagName}}",
+				"Untitled.md": "Original",
+			},
+			onOperation: (operation) => {
+				if (operation.kind === "modifyText") throw writeFailure;
+			},
+		});
+
+		await expect(populateNewNote({
+			vault: vault.vault,
+			notePath: "Untitled.md",
+			template,
+			expandedTagsAll: ["project/client"],
+			expandedTags: "#project/client",
+			frontmatterTags: ["project/client"],
+			useFrontmatterTags: false,
+			applyFrontmatterTags: vi.fn(),
+		})).rejects.toBe(writeFailure);
+
+		expect(vault.transcript).toEqual([
+			{ kind: "readText", path: template.path },
+			{ kind: "modifyText", path: "Untitled.md", content: "# project/client" },
+		]);
+		expect(vault.getFile("Untitled.md")).toBe("Original");
+	});
 });


### PR DESCRIPTION
## Summary

- narrow the new-note template workflow to the `pickOne` UI capability;
- narrow note population to `readText`, `modifyText`, and `appendText`; and
- add a Vault harness failure test proving that a rejected write propagates without changing the note.

## Impact

The production adapter still satisfies these structural types, so runtime behaviour is unchanged. Tests and collaborators can now supply only the operations this workflow actually uses.

## Validation

- 31 tests passed;
- ESLint;
- Svelte check;
- TypeScript check;
- production build;
- real-Obsidian E2E typecheck; and
- real Obsidian 1.12.7: isolated plug-in enable/reload, template selection through the picker, and Vault write passed.
