### PR TITLE
Use shared Vault frontmatter access

### DIFF
--- a/docs/devs.md
+++ b/docs/devs.md
@@ -14,11 +14,12 @@ The App-free Vitest suite includes TagFolder tree utilities and the new-note app
 
 ## UI and Vault boundaries
 
-The plug-in owns one `UiInteractions` capability and one `VaultTextAccess` capability for its lifetime:
+The plug-in owns one `UiInteractions` capability, one `VaultTextAccess` capability, and one `VaultFrontmatterAccess` capability for its lifetime:
 
 ```ts
 this.ui = createObsidianUi(this.app);
 this.vaultText = createObsidianVaultTextAccess(this.app.vault);
+this.vaultFrontmatter = createObsidianVaultFrontmatterAccess(this.app);
 ```
 
 `new-note-workflow.ts` accepts those capabilities instead of constructing an Obsidian template modal or reading and writing `TFile` instances directly. TagFolder still owns template variables, frontmatter policy, note creation, settings, and visible labels.
@@ -35,9 +36,12 @@ const vault = createVaultTextTestHarness({
 		"Untitled.md": "",
 	},
 });
+const frontmatter = createVaultFrontmatterTestHarness({
+	files: { "Untitled.md": { tags: [] } },
+});
 ```
 
-The UI transcript verifies the stable interaction ID and selected object identity. The Vault transcript verifies template reads, note writes, write ordering, and the absence of text writes when frontmatter owns the update.
+The UI transcript verifies the stable interaction ID and selected object identity. The Vault text transcript verifies template reads, note writes, write ordering, and the absence of text writes when frontmatter owns the update. The frontmatter transcript verifies tag merging and rollback when a simulated update fails.
 
 The path-based Vault capability deliberately does not replace real Obsidian coverage for `TFile` identity, Vault events, MetadataCache propagation, or frontmatter processing.
 
@@ -52,4 +56,4 @@ npm run check:e2e:obsidian
 npm run test:e2e:obsidian:new-note-template
 ```
 
-The real scenario uses the production UI and Vault adapters. It selects a template through Obsidian, creates a real note, and verifies the persisted content; it never installs a scripted driver into the plug-in.
+The real scenario uses the production UI and Vault adapters. It selects a template through Obsidian, creates real notes, and verifies both persisted template content and frontmatter tags; it never installs a scripted driver into the plug-in.

--- a/main.ts
+++ b/main.ts
@@ -21,7 +21,9 @@ import {
 } from "obsidian";
 import { createObsidianUi, type UiInteractions } from "@vrtmrz/obsidian-plugin-kit/ui";
 import {
+	createObsidianVaultFrontmatterAccess,
 	createObsidianVaultTextAccess,
+	type VaultFrontmatterAccess,
 	type VaultTextAccess,
 } from "@vrtmrz/obsidian-plugin-kit/vault";
 
@@ -237,6 +239,7 @@ export default class TagFolderPlugin extends Plugin {
 	settings: TagFolderSettings = { ...DEFAULT_SETTINGS };
 	ui!: UiInteractions;
 	vaultText!: VaultTextAccess;
+	vaultFrontmatter!: VaultFrontmatterAccess;
 
 	// Folder opening status.
 	expandedFolders: string[] = ["root"];
@@ -346,6 +349,7 @@ export default class TagFolderPlugin extends Plugin {
 		await this.loadSettings();
 		this.ui = createObsidianUi(this.app);
 		this.vaultText = createObsidianVaultTextAccess(this.app.vault);
+		this.vaultFrontmatter = createObsidianVaultFrontmatterAccess(this.app);
 		this.hoverPreview = this.hoverPreview.bind(this);
 		this.modifyFile = this.modifyFile.bind(this);
 		this.setSearchString = this.setSearchString.bind(this);
@@ -1395,20 +1399,13 @@ export default class TagFolderPlugin extends Plugin {
 		if (!(ww instanceof TFile)) return;
 		await populateNewNote({
 			vault: this.vaultText,
+			frontmatter: this.vaultFrontmatter,
 			notePath: ww.path,
 			template: selectedTemplate,
 			expandedTagsAll,
 			expandedTags,
 			frontmatterTags: expandedTagsAll.filter(e => !isSpecialTag(e)),
 			useFrontmatterTags: this.settings.useFrontmatterTagsForNewNotes,
-			applyFrontmatterTags: async (frontmatterTags) => {
-				await this.app.fileManager.processFrontMatter(ww, (matter) => {
-					matter.tags = matter.tags ?? [];
-					matter.tags = frontmatterTags
-						.filter(e => matter.tags.indexOf(e) < 0)
-						.concat(matter.tags);
-				});
-			},
 		});
 	}
 }

--- a/new-note-workflow.ts
+++ b/new-note-workflow.ts
@@ -1,5 +1,8 @@
 import type { UiInteractions } from "@vrtmrz/obsidian-plugin-kit/ui";
-import type { VaultTextAccess } from "@vrtmrz/obsidian-plugin-kit/vault";
+import type {
+	VaultFrontmatterAccess,
+	VaultTextAccess,
+} from "@vrtmrz/obsidian-plugin-kit/vault";
 import { renderTagFolderTemplateVariables } from "./new-note-template";
 
 export const NEW_NOTE_TEMPLATE_INTERACTION_ID = "new-note-template";
@@ -11,6 +14,12 @@ export type NewNoteTemplateUi = Pick<UiInteractions, "pickOne">;
 export type NewNoteVaultTextAccess = Pick<
 	VaultTextAccess,
 	"readText" | "modifyText" | "appendText"
+>;
+
+/** Frontmatter capability required while populating a new note. */
+export type NewNoteVaultFrontmatterAccess = Pick<
+	VaultFrontmatterAccess,
+	"updateFrontmatter"
 >;
 
 /** Template identity and labels exposed to the application workflow. */
@@ -54,6 +63,8 @@ export async function chooseNewNoteTemplate(
 export interface PopulateNewNoteOptions {
 	/** Injectable path-based Vault text capability. */
 	readonly vault: NewNoteVaultTextAccess;
+	/** Injectable path-based Vault frontmatter capability. */
+	readonly frontmatter: NewNoteVaultFrontmatterAccess;
 	/** Vault-relative path of the already created note. */
 	readonly notePath: string;
 	/** Selected template, or `null` to apply tags without a template. */
@@ -62,12 +73,10 @@ export interface PopulateNewNoteOptions {
 	readonly expandedTagsAll: readonly string[];
 	/** Expanded hashtag string used by template variables or body append. */
 	readonly expandedTags: string;
-	/** Non-special tags supplied to the frontmatter callback. */
+	/** Non-special tags supplied to the frontmatter update. */
 	readonly frontmatterTags: readonly string[];
 	/** Whether no-template tags should be written through frontmatter. */
 	readonly useFrontmatterTags: boolean;
-	/** Consumer-owned Obsidian frontmatter mutation. */
-	readonly applyFrontmatterTags: (tags: readonly string[]) => Promise<void>;
 }
 
 /** Populates a new note from a template, frontmatter tags, or appended hashtags. */
@@ -86,7 +95,12 @@ export async function populateNewNote(options: PopulateNewNoteOptions): Promise<
 	}
 
 	if (options.useFrontmatterTags) {
-		await options.applyFrontmatterTags(options.frontmatterTags);
+		await options.frontmatter.updateFrontmatter(options.notePath, (value) => {
+			const currentTags = (value.tags ?? []) as string[];
+			value.tags = options.frontmatterTags
+				.filter((tag) => currentTags.indexOf(tag) < 0)
+				.concat(currentTags);
+		});
 		return;
 	}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "0.18.17",
 			"license": "MIT",
 			"dependencies": {
-				"@vrtmrz/obsidian-plugin-kit": "0.1.0",
+				"@vrtmrz/obsidian-plugin-kit": "0.1.1-rc.0",
 				"@vrtmrz/ui-interactions": "0.1.0"
 			},
 			"devDependencies": {
@@ -2001,9 +2001,9 @@
 			}
 		},
 		"node_modules/@vrtmrz/obsidian-plugin-kit": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/@vrtmrz/obsidian-plugin-kit/-/obsidian-plugin-kit-0.1.0.tgz",
-			"integrity": "sha512-TFuqbP+HcxFhd9zvgvSkEvLa1B49omGaOmJ5V06xyECOK696UTzH7NHfTc8+/Ji6JB9QB48cAfQ9A6kKiLxGnA==",
+			"version": "0.1.1-rc.0",
+			"resolved": "https://registry.npmjs.org/@vrtmrz/obsidian-plugin-kit/-/obsidian-plugin-kit-0.1.1-rc.0.tgz",
+			"integrity": "sha512-MoLPwWDq1CT6y4yv/My0FPhKEJUkbh2b8KKpvPqZIxK2Wt3zfCYuuT4MHsDD7W1514CKJ0FAz/+y3vNO4K7g7g==",
 			"license": "MIT",
 			"dependencies": {
 				"@vrtmrz/ui-interactions": "0.1.0"
@@ -8682,9 +8682,9 @@
 			}
 		},
 		"@vrtmrz/obsidian-plugin-kit": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/@vrtmrz/obsidian-plugin-kit/-/obsidian-plugin-kit-0.1.0.tgz",
-			"integrity": "sha512-TFuqbP+HcxFhd9zvgvSkEvLa1B49omGaOmJ5V06xyECOK696UTzH7NHfTc8+/Ji6JB9QB48cAfQ9A6kKiLxGnA==",
+			"version": "0.1.1-rc.0",
+			"resolved": "https://registry.npmjs.org/@vrtmrz/obsidian-plugin-kit/-/obsidian-plugin-kit-0.1.1-rc.0.tgz",
+			"integrity": "sha512-MoLPwWDq1CT6y4yv/My0FPhKEJUkbh2b8KKpvPqZIxK2Wt3zfCYuuT4MHsDD7W1514CKJ0FAz/+y3vNO4K7g7g==",
 			"requires": {
 				"@vrtmrz/ui-interactions": "0.1.0"
 			}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "0.18.17",
 			"license": "MIT",
 			"dependencies": {
-				"@vrtmrz/obsidian-plugin-kit": "0.1.1-rc.0",
+				"@vrtmrz/obsidian-plugin-kit": "0.1.1",
 				"@vrtmrz/ui-interactions": "0.1.0"
 			},
 			"devDependencies": {
@@ -2001,9 +2001,9 @@
 			}
 		},
 		"node_modules/@vrtmrz/obsidian-plugin-kit": {
-			"version": "0.1.1-rc.0",
-			"resolved": "https://registry.npmjs.org/@vrtmrz/obsidian-plugin-kit/-/obsidian-plugin-kit-0.1.1-rc.0.tgz",
-			"integrity": "sha512-MoLPwWDq1CT6y4yv/My0FPhKEJUkbh2b8KKpvPqZIxK2Wt3zfCYuuT4MHsDD7W1514CKJ0FAz/+y3vNO4K7g7g==",
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/@vrtmrz/obsidian-plugin-kit/-/obsidian-plugin-kit-0.1.1.tgz",
+			"integrity": "sha512-I7Ag9/+LuMIkN/JLM/m9GrzTBY2pHbhu15cdmErBapiqJ7UKNboKJKKOOhpM/Sq5vJpRKxiYD8Ib13xi64J9HQ==",
 			"license": "MIT",
 			"dependencies": {
 				"@vrtmrz/ui-interactions": "0.1.0"
@@ -8682,9 +8682,9 @@
 			}
 		},
 		"@vrtmrz/obsidian-plugin-kit": {
-			"version": "0.1.1-rc.0",
-			"resolved": "https://registry.npmjs.org/@vrtmrz/obsidian-plugin-kit/-/obsidian-plugin-kit-0.1.1-rc.0.tgz",
-			"integrity": "sha512-MoLPwWDq1CT6y4yv/My0FPhKEJUkbh2b8KKpvPqZIxK2Wt3zfCYuuT4MHsDD7W1514CKJ0FAz/+y3vNO4K7g7g==",
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/@vrtmrz/obsidian-plugin-kit/-/obsidian-plugin-kit-0.1.1.tgz",
+			"integrity": "sha512-I7Ag9/+LuMIkN/JLM/m9GrzTBY2pHbhu15cdmErBapiqJ7UKNboKJKKOOhpM/Sq5vJpRKxiYD8Ib13xi64J9HQ==",
 			"requires": {
 				"@vrtmrz/ui-interactions": "0.1.0"
 			}

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
 		"vitest": "^4.1.9"
 	},
 	"dependencies": {
-		"@vrtmrz/obsidian-plugin-kit": "0.1.0",
+		"@vrtmrz/obsidian-plugin-kit": "0.1.1-rc.0",
 		"@vrtmrz/ui-interactions": "0.1.0"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
 		"vitest": "^4.1.9"
 	},
 	"dependencies": {
-		"@vrtmrz/obsidian-plugin-kit": "0.1.1-rc.0",
+		"@vrtmrz/obsidian-plugin-kit": "0.1.1",
 		"@vrtmrz/ui-interactions": "0.1.0"
 	}
 }

--- a/test/e2e-obsidian/new-note-template.mts
+++ b/test/e2e-obsidian/new-note-template.mts
@@ -68,12 +68,77 @@ async function verifyTemplateWorkflow(testSession: TagFolderTestSession): Promis
 	});
 }
 
+async function verifyFrontmatterWorkflow(testSession: TagFolderTestSession): Promise<void> {
+	await withObsidianPage(testSession.session.remoteDebuggingPort, async (page) => {
+		const createdPath = await page.evaluate(async (pluginId) => {
+			const obsidianApp = (
+				globalThis as typeof globalThis & {
+					app?: {
+						plugins?: {
+							plugins?: Record<
+								string,
+								{
+									settings: {
+										newNoteTemplate: string;
+										useFrontmatterTagsForNewNotes: boolean;
+									};
+									createNewNote(tags: string[]): Promise<void>;
+								}
+							>;
+						};
+						vault?: { getMarkdownFiles(): Array<{ path: string }> };
+					};
+				}
+			).app;
+			const plugin = obsidianApp?.plugins?.plugins?.[pluginId];
+			const vault = obsidianApp?.vault;
+			if (!plugin || !vault) throw new Error(`TagFolder is not loaded: ${pluginId}`);
+
+			const before = new Set(vault.getMarkdownFiles().map((file) => file.path));
+			plugin.settings.newNoteTemplate = "";
+			plugin.settings.useFrontmatterTagsForNewNotes = true;
+			await plugin.createNewNote(["project/client"]);
+
+			const created = vault.getMarkdownFiles().find((file) => !before.has(file.path));
+			if (!created) throw new Error("TagFolder did not create a frontmatter note");
+			return created.path;
+		}, TAGFOLDER_PLUGIN_ID);
+
+		const result = await page.waitForFunction((notePath) => {
+			const obsidianApp = (
+				globalThis as typeof globalThis & {
+					app?: {
+						metadataCache?: {
+							getFileCache(file: unknown): { frontmatter?: Record<string, unknown> } | null;
+						};
+						vault?: {
+							getAbstractFileByPath(path: string): unknown;
+							read(file: unknown): Promise<string>;
+						};
+					};
+				}
+			).app;
+			const vault = obsidianApp?.vault;
+			const file = vault?.getAbstractFileByPath(notePath);
+			if (!vault || !file) return null;
+			const tags = obsidianApp?.metadataCache?.getFileCache(file)?.frontmatter?.tags;
+			if (!Array.isArray(tags) || tags[0] !== "project/client") return null;
+			return vault.read(file).then((content) => ({ content, tags }));
+		}, createdPath, { timeout: 10_000 });
+		const value = await result.jsonValue() as { content: string; tags: unknown };
+		if (!value.content.includes("project/client")) {
+			throw new Error(`Frontmatter tags were not serialised: ${JSON.stringify(value)}`);
+		}
+	});
+}
+
 async function main(): Promise<void> {
 	let testSession: TagFolderTestSession | undefined;
 	try {
 		testSession = await startTagFolderTestSession();
 		await verifyTemplateWorkflow(testSession);
-		console.log("TagFolder template selection and Vault write passed in real Obsidian");
+		await verifyFrontmatterWorkflow(testSession);
+		console.log("TagFolder template, Vault write, and frontmatter tags passed in real Obsidian");
 	} finally {
 		if (testSession) await stopTagFolderTestSession(testSession);
 	}

--- a/tests/new-note-workflow.test.ts
+++ b/tests/new-note-workflow.test.ts
@@ -1,8 +1,9 @@
 import {
 	createUiTestHarness,
+	createVaultFrontmatterTestHarness,
 	createVaultTextTestHarness,
 } from "@vrtmrz/obsidian-plugin-kit/testing";
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import {
 	chooseNewNoteTemplate,
 	filterNewNoteTemplateChoices,
@@ -46,19 +47,22 @@ describe("new-note workflow", () => {
 				"Untitled.md": "",
 			},
 		});
+		const frontmatter = createVaultFrontmatterTestHarness({
+			files: { "Untitled.md": {} },
+		});
 
 		const selected = await chooseNewNoteTemplate(ui.ui, [template]);
 		expect(selected).not.toBeUndefined();
 		if (selected === undefined) throw new Error("Expected a captured template selection");
 		await populateNewNote({
 			vault: vault.vault,
+			frontmatter: frontmatter.vault,
 			notePath: "Untitled.md",
 			template: selected,
 			expandedTagsAll: ["project/client"],
 			expandedTags: "#project/client",
 			frontmatterTags: ["project/client"],
 			useFrontmatterTags: false,
-			applyFrontmatterTags: vi.fn(),
 		});
 
 		expect(ui.transcript).toEqual([
@@ -88,19 +92,22 @@ describe("new-note workflow", () => {
 			{ kind: "pickOne", interactionId: NEW_NOTE_TEMPLATE_INTERACTION_ID, value: null },
 		]);
 		const vault = createVaultTextTestHarness({ files: { "Untitled.md": "" } });
+		const frontmatter = createVaultFrontmatterTestHarness({
+			files: { "Untitled.md": {} },
+		});
 
 		const selected = await chooseNewNoteTemplate(ui.ui, [template]);
 		expect(selected).not.toBeUndefined();
 		if (selected === undefined) throw new Error("Expected a dismissed template selection");
 		await populateNewNote({
 			vault: vault.vault,
+			frontmatter: frontmatter.vault,
 			notePath: "Untitled.md",
 			template: selected,
 			expandedTagsAll: ["project/client"],
 			expandedTags: "#project/client",
 			frontmatterTags: ["project/client"],
 			useFrontmatterTags: false,
-			applyFrontmatterTags: vi.fn(),
 		});
 
 		expect(vault.transcript).toEqual([
@@ -109,23 +116,34 @@ describe("new-note workflow", () => {
 		ui.assertDone();
 	});
 
-	it("delegates frontmatter mutation without issuing a text write", async () => {
+	it("prepends missing frontmatter tags without issuing a text write", async () => {
 		const vault = createVaultTextTestHarness({ files: { "Untitled.md": "" } });
-		const applyFrontmatterTags = vi.fn<(tags: readonly string[]) => Promise<void>>(async () => {});
+		const frontmatter = createVaultFrontmatterTestHarness({
+			files: {
+				"Untitled.md": { tags: ["existing", "project/client"] },
+			},
+		});
 
 		await populateNewNote({
 			vault: vault.vault,
+			frontmatter: frontmatter.vault,
 			notePath: "Untitled.md",
 			template: null,
 			expandedTagsAll: ["project/client"],
 			expandedTags: "#project/client",
-			frontmatterTags: ["project/client"],
+			frontmatterTags: ["project/client", "new"],
 			useFrontmatterTags: true,
-			applyFrontmatterTags,
 		});
 
-		expect(applyFrontmatterTags).toHaveBeenCalledWith(["project/client"]);
 		expect(vault.transcript).toEqual([]);
+		expect(frontmatter.transcript).toEqual([
+			{
+				kind: "updateFrontmatter",
+				path: "Untitled.md",
+				before: { tags: ["existing", "project/client"] },
+				after: { tags: ["new", "existing", "project/client"] },
+			},
+		]);
 	});
 
 	it("propagates a Vault write failure without changing the note", async () => {
@@ -139,16 +157,19 @@ describe("new-note workflow", () => {
 				if (operation.kind === "modifyText") throw writeFailure;
 			},
 		});
+		const frontmatter = createVaultFrontmatterTestHarness({
+			files: { "Untitled.md": {} },
+		});
 
 		await expect(populateNewNote({
 			vault: vault.vault,
+			frontmatter: frontmatter.vault,
 			notePath: "Untitled.md",
 			template,
 			expandedTagsAll: ["project/client"],
 			expandedTags: "#project/client",
 			frontmatterTags: ["project/client"],
 			useFrontmatterTags: false,
-			applyFrontmatterTags: vi.fn(),
 		})).rejects.toBe(writeFailure);
 
 		expect(vault.transcript).toEqual([
@@ -156,5 +177,31 @@ describe("new-note workflow", () => {
 			{ kind: "modifyText", path: "Untitled.md", content: "# project/client" },
 		]);
 		expect(vault.getFile("Untitled.md")).toBe("Original");
+	});
+
+	it("propagates a frontmatter failure without issuing a text write", async () => {
+		const failure = new Error("Frontmatter write failed");
+		const vault = createVaultTextTestHarness({ files: { "Untitled.md": "" } });
+		const frontmatter = createVaultFrontmatterTestHarness({
+			files: { "Untitled.md": { tags: ["existing"] } },
+			onOperation: () => {
+				throw failure;
+			},
+		});
+
+		await expect(populateNewNote({
+			vault: vault.vault,
+			frontmatter: frontmatter.vault,
+			notePath: "Untitled.md",
+			template: null,
+			expandedTagsAll: ["project/client"],
+			expandedTags: "#project/client",
+			frontmatterTags: ["project/client"],
+			useFrontmatterTags: true,
+		})).rejects.toBe(failure);
+
+		expect(vault.transcript).toEqual([]);
+		expect(frontmatter.getFrontmatter("Untitled.md")).toEqual({ tags: ["existing"] });
+		expect(frontmatter.transcript[0]?.after).toBeNull();
 	});
 });

--- a/updates.md
+++ b/updates.md
@@ -1,3 +1,10 @@
+## Unreleased
+
+### Digging the weeds
+
+-   Refactored new-note frontmatter updates through the shared Fancy Kit Vault capability without changing the visible workflow.
+-   Added App-free frontmatter transcript and failure tests, and extended the local real-Obsidian scenario to verify persisted frontmatter tags.
+
 ## 0.18.17
 
 ### Improved


### PR DESCRIPTION
## Summary

- Route new-note frontmatter-tag updates through Fancy Kit's path-based `VaultFrontmatterAccess`.
- Inject the capability into the App-free new-note workflow alongside the existing UI and Vault text capabilities.
- Add harness coverage for tag merging, transcript output, and failed-update rollback.
- Extend the local real-Obsidian scenario to verify persisted frontmatter tags.
- Pin the exact stable `@vrtmrz/obsidian-plugin-kit@0.1.1` registry release.

## Impact

There is no intentional user-visible behaviour change. New-note tags are merged with existing frontmatter tags using the same policy as before. Tag-info creation and update handling remain direct Obsidian operations because their creation semantics are outside this capability.

## Package validation

The public release candidate was exercised before `0.1.1` was published. This branch now resolves the exact stable registry tarball and its recorded integrity, rather than a local package or repository checkout.

- `@vrtmrz/obsidian-plugin-kit@0.1.1`
- published shasum: `af2e2f493be5cd7a6208b3ed2b9b87761d2dceec`

## Validation

- `npm run check`
  - lint passed
  - 32 tests across four files passed
  - Svelte check passed with no errors or warnings
  - TypeScript check passed
- `npm run build`
- `npm run check:e2e:obsidian`
- `npm run test:e2e:obsidian:new-note-template`
  - template selection, Vault writes, and frontmatter tags passed with the stable package in a real Obsidian instance on Linux

The updated branch CI provides the clean-install remote gate for the stable dependency.
