### PR TITLE
Preserve Markdown in generated release PRs

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -94,7 +94,7 @@ jobs:
           VERSION: ${{ inputs.version }}
           RELEASE_BRANCH: ${{ steps.prepare.outputs.branch }}
         run: |
-          cat > /tmp/release-pr-body.md <<EOF
+          cat > /tmp/release-pr-body.md <<'EOF'
           > [!IMPORTANT]
           > **Merge intentionally on hold**
           >
@@ -103,7 +103,7 @@ jobs:
           ## Release checklist
 
           - [ ] Review and polish `updates.md`
-          - [ ] Confirm `package.json`, `manifest.json`, and `versions.json` use `${VERSION}`
+          - [ ] Confirm `package.json`, `manifest.json`, and `versions.json` use `__VERSION__`
           - [ ] Confirm CI has passed
           - [ ] Run `Finalise Release Tags` with this pull request's fixed head SHA
           - [ ] Approve `Finalise Release Tags` for the `release` environment to create the fixed tag
@@ -115,6 +115,7 @@ jobs:
 
           If BRAT validation fails, do not move the published tag. Keep this pull request in draft and prepare a new patch release.
           EOF
+          sed -i "s/__VERSION__/${VERSION}/g" /tmp/release-pr-body.md
 
           gh pr create \
             --base main \

--- a/tests/release-process.test.ts
+++ b/tests/release-process.test.ts
@@ -61,6 +61,9 @@ describe("release workflow contracts", () => {
 		expect(workflow).toContain("Validate the published release with BRAT");
 		expect(workflow).toContain("merge it with a merge commit");
 		expect(workflow).toContain("gh workflow run ci.yml");
+		expect(workflow).toContain("<<'EOF'");
+		expect(workflow).toContain('sed -i "s/__VERSION__/${VERSION}/g"');
+		expect(workflow).not.toContain("<<EOF");
 	});
 
 	it("fixes finalisation to the reviewed head and explicitly dispatches publishing", () => {


### PR DESCRIPTION
## Summary

- quote the generated release pull request body heredoc so that Markdown backticks remain literal
- replace only the validated release-version placeholder after the body has been written
- add a contract test that rejects an unquoted heredoc

## Root cause

The shared release preparation template used an unquoted shell heredoc. Markdown backticks would therefore be interpreted as command substitutions when the first TagFolder release pull request was generated. ScrewDriver's first run demonstrated the resulting missing identifiers before this workflow was used for TagFolder.

## Impact

This changes release automation only. It does not change plug-in runtime behaviour. Merging this pull request also gives GitHub Actions a new `main` push from which to index the recently added release workflows.

## Validation

- `actionlint`
- `npm run check` — 37 tests, with no Svelte diagnostics
- `git diff --check`
