### PR TITLE
Serialise release finalisation

### DIFF
--- a/.github/workflows/finalise-release.yml
+++ b/.github/workflows/finalise-release.yml
@@ -16,6 +16,10 @@ on:
         required: true
         type: string
 
+concurrency:
+  group: finalise-release
+  cancel-in-progress: false
+
 jobs:
   finalise:
     runs-on: ubuntu-latest

--- a/tests/release-process.test.ts
+++ b/tests/release-process.test.ts
@@ -71,6 +71,8 @@ describe("release workflow contracts", () => {
 		expect(workflow).toContain("expected_head_sha");
 		expect(workflow).toContain("actions: write");
 		expect(workflow).toContain("gh workflow run release.yml");
+		expect(workflow).toContain("group: finalise-release");
+		expect(workflow).toContain("cancel-in-progress: false");
 	});
 
 	it("supports an explicit tag and draft state in the publishing workflow", () => {


### PR DESCRIPTION
## Summary

- serialise `Finalise Release Tags` runs at repository scope
- retain an active finalisation run and queue any later request instead of cancelling it
- add contract coverage for the concurrency policy

## Why

The original automation merge reached `main` without its push event being processed by GitHub Actions. A later push registered `Prepare Release PR`, because that workflow was changed, but the unchanged `Finalise Release Tags` file remains absent from the Actions workflow registry.

Touching the finalisation workflow through this pull request allows GitHub Actions to register it. The concurrency policy is also a useful safety constraint: two tag finalisations must not create and dispatch releases at the same time.

## Impact

This changes release automation only. It does not change plug-in runtime behaviour or release metadata.

## Validation

- `actionlint`
- `npm run check` — 37 tests, with no Svelte diagnostics
- `git diff --check`
